### PR TITLE
Using pytorch builtin avoids no-grad params

### DIFF
--- a/train.py
+++ b/train.py
@@ -150,16 +150,7 @@ def main():
             optimizer.zero_grad()
             loss.backward()
 
-            # rescale gradients if necessary
-            total_norm = torch.FloatTensor([0])
-            for param in model.parameters():
-                param = param.norm().pow(2).data.cpu()
-                total_norm.add_(param)
-            total_norm = total_norm.sqrt()
-            if total_norm[0] > args.max_norm:
-                for param in model.parameters():
-                    param.grad.mul_(args.max_norm / total_norm[0])
-
+            torch.nn.utils.clip_grad_norm(model.parameters(), args.max_norm)
             # SGD step
             optimizer.step()
 


### PR DESCRIPTION
Running a dataset besides an4 I hit this, and got NoneType errors since params with no gradients arent filtered.  The pytorch utility torch.nn.utils.clip_grad_norm does this filtering internally, and once I replaced the clipping code with it, the exception went away