### PR TITLE
Fix model saving for different RNN types

### DIFF
--- a/model.py
+++ b/model.py
@@ -2,6 +2,7 @@ import math
 from collections import OrderedDict
 
 import torch.nn as nn
+import torch
 
 supported_rnns = {
     'lstm': nn.LSTM,
@@ -102,3 +103,11 @@ class DeepSpeech(nn.Module):
         x = self.fc(x)
         x = x.transpose(0, 1)  # Transpose for multi-gpu concat
         return x
+
+    @classmethod
+    def load_model(cls, path):
+        package = torch.load(path)
+        model = cls(rnn_hidden_size=package['hidden_size'], nb_layers=package['hidden_layers'],
+                    num_classes=package['nout'], rnn_type=supported_rnns[package['rnn_type']])
+        model.load_state_dict(package['state_dict'])
+        return model

--- a/predict.py
+++ b/predict.py
@@ -18,16 +18,15 @@ parser.add_argument('--audio_path', default='audio.wav',
 parser.add_argument('--window_size', default=.02, type=float, help='Window size for spectrogram in seconds')
 parser.add_argument('--window_stride', default=.01, type=float, help='Window stride for spectrogram in seconds')
 parser.add_argument('--window', default='hamming', help='Window type for spectrogram generation')
-parser.add_argument('--cuda', default=True, type=bool, help='Use cuda to train model')
+parser.add_argument('--cuda', action="store_true", help='Use cuda to test model')
 args = parser.parse_args()
 
 if __name__ == '__main__':
-    package = torch.load(args.model_path)
-    model = DeepSpeech(rnn_hidden_size=package['hidden_size'], nb_layers=package['hidden_layers'],
-                       num_classes=package['nout'])
+    model = DeepSpeech.load_model(args.model_path)
     if args.cuda:
         model = torch.nn.DataParallel(model).cuda()
-    model.load_state_dict(package['state_dict'])
+    model.eval()
+
     audio_conf = dict(sample_rate=args.sample_rate,
                       window_size=args.window_size,
                       window_stride=args.window_stride,

--- a/test.py
+++ b/test.py
@@ -13,12 +13,10 @@ parser.add_argument('--sample_rate', default=16000, type=int, help='Sample rate'
 parser.add_argument('--labels_path', default='labels.json', help='Contains all characters for prediction')
 parser.add_argument('--model_path', default='models/deepspeech_final.pth.tar',
                     help='Path to model file created by training')
-parser.add_argument('--audio_path', default='audio.wav',
-                    help='Audio file to predict on')
 parser.add_argument('--window_size', default=.02, type=float, help='Window size for spectrogram in seconds')
 parser.add_argument('--window_stride', default=.01, type=float, help='Window stride for spectrogram in seconds')
 parser.add_argument('--window', default='hamming', help='Window type for spectrogram generation')
-parser.add_argument('--cuda', default=True, type=bool, help='Use cuda to train model')
+parser.add_argument('--cuda', action="store_true", help='Use cuda to test model')
 parser.add_argument('--val_manifest', metavar='DIR',
                     help='path to validation manifest csv', default='data/val_manifest.csv')
 parser.add_argument('--batch_size', default=20, type=int, help='Batch size for training')
@@ -26,12 +24,9 @@ parser.add_argument('--num_workers', default=4, type=int, help='Number of worker
 args = parser.parse_args()
 
 if __name__ == '__main__':
-    package = torch.load(args.model_path)
-    model = DeepSpeech(rnn_hidden_size=package['hidden_size'], nb_layers=package['hidden_layers'],
-                       num_classes=package['nout'])
+    model = DeepSpeech.load_model(args.model_path)
     if args.cuda:
         model = torch.nn.DataParallel(model).cuda()
-    model.load_state_dict(package['state_dict'])
     model.eval()
 
     with open(args.labels_path) as label_file:
@@ -81,5 +76,5 @@ if __name__ == '__main__':
     cer = total_cer / len(test_loader.dataset)
 
     print('Validation Summary \t'
-          'Average WER {wer:.0f}\t'
-          'Average CER {cer:.0f}\t'.format(wer=wer * 100, cer=cer * 100))
+          'Average WER {wer:.3f}\t'
+          'Average CER {cer:.3f}\t'.format(wer=wer * 100, cer=cer * 100))

--- a/train.py
+++ b/train.py
@@ -63,7 +63,7 @@ class AverageMeter(object):
 
 
 def checkpoint(model, optimizer, args, nout, epoch=None, iteration=None, loss_results=None, cer_results=None,
-               wer_results=None, avg_loss=None):
+               wer_results=None, avg_loss=None, rnn_type="lstm"):
     package = {
         'epoch': epoch + 1 if epoch is not None else 'N/A',
         'iteration': iteration if iteration is not None else 'N/A',
@@ -72,7 +72,8 @@ def checkpoint(model, optimizer, args, nout, epoch=None, iteration=None, loss_re
         'hidden_layers': args.hidden_layers,
         'nout': nout,
         'state_dict': model.state_dict(),
-        'optim_dict': optimizer.state_dict()
+        'optim_dict': optimizer.state_dict(),
+        'rnn_type': rnn_type
     }
     if loss_results is not None:
         package['loss_results'] = loss_results
@@ -231,7 +232,7 @@ def main():
                 print("Saving checkpoint model to %s" % file_path)
                 torch.save(
                     checkpoint(model, optimizer, args, len(labels), epoch=epoch, iteration=i, loss_results=loss_results,
-                               wer_results=wer_results, cer_results=cer_results, avg_loss=avg_loss),
+                               wer_results=wer_results, cer_results=cer_results, avg_loss=avg_loss, rnn_type=rnn_type),
                     file_path)
         avg_loss /= len(train_loader)
 
@@ -280,8 +281,8 @@ def main():
         cer *= 100
 
         print('Validation Summary Epoch: [{0}]\t'
-              'Average WER {wer:.0f}\t'
-              'Average CER {cer:.0f}\t'.format(
+              'Average WER {wer:.3f}\t'
+              'Average CER {cer:.3f}\t'.format(
             epoch + 1, wer=wer, cer=cer))
 
         if args.visdom:
@@ -308,7 +309,7 @@ def main():
         if args.checkpoint:
             file_path = '%s/deepspeech_%d.pth.tar' % (save_folder, epoch + 1)
             torch.save(checkpoint(model, optimizer, args, len(labels), epoch, loss_results=loss_results,
-                                  wer_results=wer_results, cer_results=cer_results),
+                                  wer_results=wer_results, cer_results=cer_results, rnn_type=rnn_type),
                        file_path)
         # anneal lr
         optim_state = optimizer.state_dict()
@@ -317,7 +318,7 @@ def main():
         print('Learning rate annealed to: {lr:.6f}'.format(lr=optim_state['param_groups'][0]['lr']))
 
         avg_loss = 0
-    torch.save(checkpoint(model, optimizer, args, len(labels)), args.final_model_path)
+    torch.save(checkpoint(model, optimizer, args, len(labels)), args.final_model_path, rnn_type=rnn_type)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When you train with a non-LSTM model, the test and predict scripts cannot properly load the model because the RNN type is not saved as metadata. Other miscellaneous fixes included (largely related to command-line arguments).