### PR TITLE
Refactor model serialization & deserialization for CPU/GPU portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Use the flag `--help` to see other parameters that can be used with the script.
 Saved models contain the metadata of their training process. To see the metadata run the below command:
 
 ```
-python model --model_path models/deepspeech.pth.tar
+python model.py --model_path models/deepspeech.pth.tar
 ```
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ python benchmark.py --batch_size 32
 
 Use the flag `--help` to see other parameters that can be used with the script.
 
+### Model details
+
+Saved models contain the metadata of their training process. To see the metadata run the below command:
+
+```
+python model --model_path models/deepspeech.pth.tar
+```
+
 ## Acknowledgements
 
-Thanks to [Egor](https://github.com/EgorLakomkin) for his awesome contributions in data processing and general feedback!
+Thanks to [Egor](https://github.com/EgorLakomkin) and [Ryan](https://github.com/ryanleary) for their contributions!

--- a/model.py
+++ b/model.py
@@ -155,3 +155,13 @@ class DeepSpeech(nn.Module):
         if meta is not None:
             package['meta'] = meta
         return package
+
+    @staticmethod
+    def get_labels(model):
+        model_is_cuda = next(model.parameters()).is_cuda
+        return model.module._labels if model_is_cuda else model._labels
+
+    @staticmethod
+    def get_audio_conf(model):
+        model_is_cuda = next(model.parameters()).is_cuda
+        return model.module._audio_conf if model_is_cuda else model._audio_conf

--- a/model.py
+++ b/model.py
@@ -118,7 +118,8 @@ class DeepSpeech(nn.Module):
         return x
 
     @classmethod
-    def load_model(cls, package, cuda):
+    def load_model(cls, path, cuda=False):
+        package = torch.load(path, map_location=lambda storage, loc: storage)
         model = cls(rnn_hidden_size=package['hidden_size'], nb_layers=package['hidden_layers'],
                     labels=package['labels'], audio_conf=package['audio_conf'], rnn_type=supported_rnns[package['rnn_type']])
         model.load_state_dict(package['state_dict'])

--- a/predict.py
+++ b/predict.py
@@ -20,9 +20,9 @@ if __name__ == '__main__':
     model = DeepSpeech.load_model(package, cuda=args.cuda)
     model.eval()
 
-    labels = model._labels
-    audio_conf = model._audio_conf
-    
+    labels = DeepSpeech.get_labels(model)
+    audio_conf = DeepSpeech.get_labels(model)
+
     decoder = ArgMaxDecoder(labels)
     parser = SpectrogramParser(audio_conf, normalize=True)
     spect = parser.parse_audio(args.audio_path).contiguous()

--- a/predict.py
+++ b/predict.py
@@ -20,8 +20,9 @@ if __name__ == '__main__':
     model = DeepSpeech.load_model(package, cuda=args.cuda)
     model.eval()
 
-    labels = package['labels']
-    audio_conf = package['audio_conf']
+    labels = model._labels
+    audio_conf = model._audio_conf
+    
     decoder = ArgMaxDecoder(labels)
     parser = SpectrogramParser(audio_conf, normalize=True)
     spect = parser.parse_audio(args.audio_path).contiguous()

--- a/predict.py
+++ b/predict.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     model.eval()
 
     labels = DeepSpeech.get_labels(model)
-    audio_conf = DeepSpeech.get_labels(model)
+    audio_conf = DeepSpeech.get_audio_conf(model)
 
     decoder = ArgMaxDecoder(labels)
     parser = SpectrogramParser(audio_conf, normalize=True)

--- a/predict.py
+++ b/predict.py
@@ -16,8 +16,7 @@ parser.add_argument('--cuda', action="store_true", help='Use cuda to test model'
 args = parser.parse_args()
 
 if __name__ == '__main__':
-    package = torch.load(args.model_path)
-    model = DeepSpeech.load_model(package, cuda=args.cuda)
+    model = DeepSpeech.load_model(args.model_path, cuda=args.cuda)
     model.eval()
 
     labels = DeepSpeech.get_labels(model)

--- a/test.py
+++ b/test.py
@@ -19,12 +19,12 @@ parser.add_argument('--num_workers', default=4, type=int, help='Number of worker
 args = parser.parse_args()
 
 if __name__ == '__main__':
-    package = torch.load(args.model_path)
-    model = DeepSpeech.load_model(package, cuda=args.cuda)
+    model = DeepSpeech.load_model(args.model_path, cuda=args.cuda)
     model.eval()
 
     labels = DeepSpeech.get_labels(model)
     audio_conf = DeepSpeech.get_audio_conf(model)
+    decoder = ArgMaxDecoder(labels)
 
     test_dataset = SpectrogramDataset(audio_conf=audio_conf, manifest_filepath=args.val_manifest, labels=labels,
                                       normalize=True)

--- a/test.py
+++ b/test.py
@@ -23,8 +23,8 @@ if __name__ == '__main__':
     model = DeepSpeech.load_model(package, cuda=args.cuda)
     model.eval()
 
-    labels = package['labels']
-    audio_conf = package['audio_conf']
+    labels = model._labels
+    audio_conf = model._audio_conf
 
     test_dataset = SpectrogramDataset(audio_conf=audio_conf, manifest_filepath=args.val_manifest, labels=labels,
                                       normalize=True)

--- a/test.py
+++ b/test.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
     model.eval()
 
     labels = DeepSpeech.get_labels(model)
-    audio_conf = DeepSpeech.get_labels(model)
+    audio_conf = DeepSpeech.get_audio_conf(model)
 
     test_dataset = SpectrogramDataset(audio_conf=audio_conf, manifest_filepath=args.val_manifest, labels=labels,
                                       normalize=True)

--- a/test.py
+++ b/test.py
@@ -23,8 +23,8 @@ if __name__ == '__main__':
     model = DeepSpeech.load_model(package, cuda=args.cuda)
     model.eval()
 
-    labels = model._labels
-    audio_conf = model._audio_conf
+    labels = DeepSpeech.get_labels(model)
+    audio_conf = DeepSpeech.get_labels(model)
 
     test_dataset = SpectrogramDataset(audio_conf=audio_conf, manifest_filepath=args.val_manifest, labels=labels,
                                       normalize=True)

--- a/train.py
+++ b/train.py
@@ -217,8 +217,8 @@ def main():
             if args.checkpoint_per_batch > 0 and i > 0 and (i + 1) % args.checkpoint_per_batch == 0:
                 file_path = '%s/deepspeech_checkpoint_epoch_%d_iter_%d.pth.tar' % (save_folder, epoch + 1, i + 1)
                 print("Saving checkpoint model to %s" % file_path)
-                torch.save(model.serialize(optimizer=optimizer, epoch=epoch, iteration=i, loss_results=loss_results,
-                                           wer_results=wer_results, cer_results=cer_results, avg_loss=avg_loss),
+                torch.save(DeepSpeech.serialize(model, optimizer=optimizer, epoch=epoch, iteration=i, loss_results=loss_results,
+                                                wer_results=wer_results, cer_results=cer_results, avg_loss=avg_loss),
                            file_path)
         avg_loss /= len(train_loader)
 
@@ -294,8 +294,8 @@ def main():
                     )
         if args.checkpoint:
             file_path = '%s/deepspeech_%d.pth.tar' % (save_folder, epoch + 1)
-            torch.save(model.serialize(optimizer=optimizer, epoch=epoch, loss_results=loss_results,
-                                       wer_results=wer_results, cer_results=cer_results),
+            torch.save(DeepSpeech.serialize(model, optimizer=optimizer, epoch=epoch, loss_results=loss_results,
+                                            wer_results=wer_results, cer_results=cer_results),
                        file_path)
         # anneal lr
         optim_state = optimizer.state_dict()
@@ -304,7 +304,7 @@ def main():
         print('Learning rate annealed to: {lr:.6f}'.format(lr=optim_state['param_groups'][0]['lr']))
 
         avg_loss = 0
-    torch.save(model.serialize(optimizer=optimizer), args.final_model_path)
+    torch.save(DeepSpeech.serialize(model, optimizer=optimizer), args.final_model_path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This merge request reworks the model saving/loading/checkpoint code. There are some breaking API changes here, so it's worth looking over carefully to ensure that they're all desirable changes.

At a high level, the checkpointing works the same way: we create a dict of the various metadata and extract the `state_dict`. This dict is then written with `torch.save`. What's different is that all of the model hyperparemeters are stored within the `DeepSpeech` model module. This simplifies some of the arguments that need passing during training and model loading.

To make the models GPU/CPU agnostic, the serialization code checks to see if the model is currently in CUDA mode. We assume that whenever this happens, `DataParallel` has also been used (which is a safe assumption considering how the loading code also works). With this information, it is possible to pull the content of the `state_dict` and have them load on CPU (per https://discuss.pytorch.org/t/solved-keyerror-unexpected-key-module-encoder-embedding-weight-in-state-dict/1686). At loading time, all tensors are forced to the CPU. Then, based on the `cuda` flag, they can then be remapped to 1 (or more) GPUs. Doing it this way further enables us to use the same model on machines with a number of GPUs different from the number of GPUs used during training.

I've also added a small `main()` section to `model.py` for printing out information about a model.