### PR TITLE
Filtering by minimum and maximum duration individually

### DIFF
--- a/data/merge_manifests.py
+++ b/data/merge_manifests.py
@@ -10,9 +10,9 @@ from utils import update_progress
 
 parser = argparse.ArgumentParser(description='Merges all manifest CSV files in specified folder.')
 parser.add_argument('--merge_dir', default='manifests/', help='Path to all manifest files you want to merge')
-parser.add_argument('--min_duration', default=-1,
+parser.add_argument('--min_duration', default=-1, type=int,
                     help='Optionally prunes any samples shorter than the min duration (given in seconds, default off)')
-parser.add_argument('--max_duration', default=-1,
+parser.add_argument('--max_duration', default=-1, type=int,
                     help='Optionally prunes any samples longer than the max duration (given in seconds, default off)')
 parser.add_argument('--output_path', default='merged_manifest.csv', help='Output path to merged manifest')
 
@@ -24,9 +24,12 @@ for file in os.listdir(args.merge_dir):
         with open(os.path.join(args.merge_dir, file), 'r') as fh:
             files += fh.readlines()
 
-prune_files = args.min_duration >= 0 and args.max_duration >= 0
-if prune_files:
-    print("Pruning files with minimum duration %d, maximum duration of %d" % (args.min_duration, args.max_duration))
+prune_min = args.min_duration >= 0
+prune_max = args.max_duration >= 0
+if prune_min:
+    print("Pruning files with minimum duration %d" % (args.min_duration))
+if prune_max:
+    print("Pruning files with  maximum duration of %d" % (args.max_duration))
 
 new_files = []
 size = len(files)
@@ -38,8 +41,15 @@ for x in range(size):
         shell=True
     )
     duration = float(output)
-    if prune_files:
-        if args.min_duration <= duration <= args.max_duration:
+    if prune_min or prune_max:
+        duration_fit = True
+        if prune_min:
+            if duration < args.min_duration:
+                duration_fit = False
+        if prune_max:
+            if duration > args.max_duration:
+                duration_fit = False
+        if duration_fit:
             new_files.append((files[x], duration))
     else:
         new_files.append((files[x], duration))


### PR DESCRIPTION
At the moment merge_manifests.py allows to set  min/max duration only jointly. This PR adds functionality to filter utterances by min/max individually.