### PR TITLE
Fix train continue bug on cuda models

### DIFF
--- a/train.py
+++ b/train.py
@@ -129,8 +129,7 @@ def main():
     optimizer = torch.optim.SGD(parameters, lr=args.lr,
                                 momentum=args.momentum, nesterov=True)
     decoder = ArgMaxDecoder(labels)
-    if args.cuda:
-        model = torch.nn.DataParallel(model).cuda()
+
     if args.continue_from:
         print("Loading checkpoint model %s" % args.continue_from)
         package = torch.load(args.continue_from)
@@ -161,6 +160,8 @@ def main():
         avg_loss = 0
         start_epoch = 0
         start_iter = 0
+    if args.cuda:
+        model = torch.nn.DataParallel(model).cuda()
 
     print(model)
     batch_time = AverageMeter()


### PR DESCRIPTION
With the new model serialization format, models are saved as the CPU version always, so the `DataParallel()`/`cuda()` calls must always *follow* the `load_state_dict` calls. I introduced this error with the model serialization refactor. Sorry about that -- had this PR ready to go and then live intervened.