### PR TITLE
Manually set autograd params for reduced memory

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -55,15 +55,15 @@ def iteration(input_data):
     target_size = torch.IntTensor(batch_size).fill_(int((seconds * 100) / 2))
     input_percentages = torch.IntTensor(batch_size).fill_(1)
 
-    inputs = Variable(input_data)
-    target_sizes = Variable(target_size)
-    targets = Variable(target)
+    inputs = Variable(input_data, requires_grad=False)
+    target_sizes = Variable(target_size requires_grad=False)
+    targets = Variable(target requires_grad=False)
     start = time.time()
     out = model(inputs)
     out = out.transpose(0, 1)  # TxNxH
 
     seq_length = out.size(0)
-    sizes = Variable(input_percentages.mul_(int(seq_length)).int())
+    sizes = Variable(input_percentages.mul_(int(seq_length)).int() requires_grad=False)
     loss = criterion(out, targets, sizes, target_sizes)
     loss = loss / inputs.size(0)  # average the loss by minibatch
     # compute gradient

--- a/predict.py
+++ b/predict.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
     parser = SpectrogramParser(audio_conf, normalize=True)
     spect = parser.parse_audio(args.audio_path).contiguous()
     spect = spect.view(1, 1, spect.size(0), spect.size(1))
-    out = model(Variable(spect))
+    out = model(Variable(spect, volatile=True))
     out = out.transpose(0, 1)  # TxNxH
     decoded_output = decoder.decode(out.data)
     print(decoded_output[0])

--- a/test.py
+++ b/test.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
     for i, (data) in enumerate(test_loader):
         inputs, targets, input_percentages, target_sizes = data
 
-        inputs = Variable(inputs)
+        inputs = Variable(inputs, volatile=True)
 
         # unflatten targets
         split_targets = []
@@ -49,7 +49,7 @@ if __name__ == '__main__':
         out = model(inputs)
         out = out.transpose(0, 1)  # TxNxH
         seq_length = out.size(0)
-        sizes = Variable(input_percentages.mul_(int(seq_length)).int())
+        sizes = Variable(input_percentages.mul_(int(seq_length)).int(), volatile=True)
 
         decoded_output = decoder.decode(out.data, sizes)
         target_strings = decoder.process_strings(decoder.convert_to_strings(split_targets))

--- a/train.py
+++ b/train.py
@@ -177,9 +177,9 @@ def main():
             inputs, targets, input_percentages, target_sizes = data
             # measure data loading time
             data_time.update(time.time() - end)
-            inputs = Variable(inputs)
-            target_sizes = Variable(target_sizes)
-            targets = Variable(targets)
+            inputs = Variable(inputs, requires_grad=False)
+            target_sizes = Variable(target_sizes, requires_grad=False)
+            targets = Variable(targets. reqiores_grad=False)
 
             if args.cuda:
                 inputs = inputs.cuda()
@@ -188,7 +188,7 @@ def main():
             out = out.transpose(0, 1)  # TxNxH
 
             seq_length = out.size(0)
-            sizes = Variable(input_percentages.mul_(int(seq_length)).int())
+            sizes = Variable(input_percentages.mul_(int(seq_length)).int(), requires_grad=False)
 
             loss = criterion(out, targets, sizes, target_sizes)
             loss = loss / inputs.size(0)  # average the loss by minibatch
@@ -243,7 +243,7 @@ def main():
         for i, (data) in enumerate(test_loader):  # test
             inputs, targets, input_percentages, target_sizes = data
 
-            inputs = Variable(inputs)
+            inputs = Variable(inputs, volatile=True)
 
             # unflatten targets
             split_targets = []
@@ -258,7 +258,7 @@ def main():
             out = model(inputs)
             out = out.transpose(0, 1)  # TxNxH
             seq_length = out.size(0)
-            sizes = Variable(input_percentages.mul_(int(seq_length)).int())
+            sizes = Variable(input_percentages.mul_(int(seq_length)).int(), volatile=True)
 
             decoded_output = decoder.decode(out.data, sizes)
             target_strings = decoder.process_strings(decoder.convert_to_strings(split_targets))


### PR DESCRIPTION
This PR reduces the memory footprint (mostly during inference) by eliminating portions of the autograd graph. I'm trying to track down any possible way we might reduce the overall memory footprint (esp. during training) to allow larger batch sizes. This was the first inefficiency I found.

What's interesting is:
1) I didn't notice much change in memory utilization during training/benchmark.
2) I noticed a SIGNIFICANT drop in memory usage during test.py, but no real speedup from dramatically increasing the batch size (though there was no OOM).