### PR TITLE
Sampler that splits utterances into buckets

### DIFF
--- a/data/bucketing_sampler.py
+++ b/data/bucketing_sampler.py
@@ -3,22 +3,27 @@ import numpy as np
 from data.data_loader import SpectrogramDataset, load_audio
 from collections import defaultdict
 
+
 class SpectrogramDatasetWithLength(SpectrogramDataset):
     def __init__(self, *args, **kwargs):
         super(SpectrogramDatasetWithLength, self).__init__(*args, **kwargs)
         audio_paths = [path for (path, _) in self.ids]
-        audio_lengths = [len(load_audio(path)) for path in audio_paths ]
+        audio_lengths = [len(load_audio(path)) for path in audio_paths]
         hist, bin_edges = np.histogram(audio_lengths, bins="auto")
         audio_samples_indices = np.digitize(audio_lengths, bins=bin_edges)
         self.bins_to_samples = defaultdict(list)
         for idx, bin_id in enumerate(audio_samples_indices):
             self.bins_to_samples[bin_id].append(idx)
 
-class BucketingSampler(Sampler):
-    """
-    """
 
+class BucketingSampler(Sampler):
     def __init__(self, data_source):
+        """
+        Samples from a dataset that has been bucketed into bins of similar sized sequences to reduce
+        memory overhead.
+        :param data_source: The dataset to be sampled from
+        """
+        super().__init__(data_source)
         self.data_source = data_source
         assert hasattr(self.data_source, 'bins_to_samples')
 
@@ -30,4 +35,3 @@ class BucketingSampler(Sampler):
 
     def __len__(self):
         return len(self.data_source)
-

--- a/data/bucketing_sampler.py
+++ b/data/bucketing_sampler.py
@@ -6,6 +6,11 @@ from collections import defaultdict
 
 class SpectrogramDatasetWithLength(SpectrogramDataset):
     def __init__(self, *args, **kwargs):
+        """
+        SpectrogramDataset that splits utterances into buckets based on their length.
+        Bucketing is done via numpy's histogram method.
+        Used by BucketingSampler to sample utterances from the same bin.
+        """
         super(SpectrogramDatasetWithLength, self).__init__(*args, **kwargs)
         audio_paths = [path for (path, _) in self.ids]
         audio_lengths = [len(load_audio(path)) for path in audio_paths]

--- a/data/bucketing_sampler.py
+++ b/data/bucketing_sampler.py
@@ -1,0 +1,33 @@
+from torch.utils.data.sampler import Sampler
+import numpy as np
+from data.data_loader import SpectrogramDataset, load_audio
+from collections import defaultdict
+
+class SpectrogramDatasetWithLength(SpectrogramDataset):
+    def __init__(self, *args, **kwargs):
+        super(SpectrogramDatasetWithLength, self).__init__(*args, **kwargs)
+        audio_paths = [path for (path, _) in self.ids]
+        audio_lengths = [len(load_audio(path)) for path in audio_paths ]
+        hist, bin_edges = np.histogram(audio_lengths, bins="auto")
+        audio_samples_indices = np.digitize(audio_lengths, bins=bin_edges)
+        self.bins_to_samples = defaultdict(list)
+        for idx, bin_id in enumerate(audio_samples_indices):
+            self.bins_to_samples[bin_id].append(idx)
+
+class BucketingSampler(Sampler):
+    """
+    """
+
+    def __init__(self, data_source):
+        self.data_source = data_source
+        assert hasattr(self.data_source, 'bins_to_samples')
+
+    def __iter__(self):
+        for bin, sample_idx in self.data_source.bins_to_samples.items():
+            np.random.shuffle(sample_idx)
+            for s in sample_idx:
+                yield s
+
+    def __len__(self):
+        return len(self.data_source)
+

--- a/data/merge_manifests.py
+++ b/data/merge_manifests.py
@@ -37,7 +37,7 @@ for x in range(size):
     file_path = files[x]
     file_path = file_path.split(',')[0]
     output = subprocess.check_output(
-        ['soxi -D %s' % file_path.strip()],
+        ['soxi -D \"%s\"' % file_path.strip()],
         shell=True
     )
     duration = float(output)

--- a/data/utils.py
+++ b/data/utils.py
@@ -43,7 +43,7 @@ def _order_files(file_paths):
 
     def func(element):
         output = subprocess.check_output(
-            ['soxi -D %s' % element.strip()],
+            ['soxi -D \"%s\"' % element.strip()],
             shell=True
         )
         return float(output)

--- a/train.py
+++ b/train.py
@@ -53,11 +53,15 @@ parser.add_argument('--noise_max', default=0.5,
 parser.add_argument('--tensorboard', dest='tensorboard', action='store_true', help='Turn on tensorboard graphing')
 parser.add_argument('--log_dir', default='visualize/deepspeech_final', help='Location of tensorboard log')
 parser.add_argument('--log_params', dest='log_params', action='store_true', help='Log parameter values and gradients')
-parser.add_argument('--bucketing', dest='bucketing', action='store_true', help='Split utterances into buckets and sample from them')
-parser.set_defaults(cuda=False, silent=False, checkpoint=False, visdom=False, augment=False, tensorboard=False, log_params=False)
+parser.add_argument('--no_bucketing', dest='no_bucketing', action='store_false',
+                    help='Turn off bucketing and sample from dataset based on sequence length (smallest to largest)')
+parser.set_defaults(cuda=False, silent=False, checkpoint=False, visdom=False, augment=False, tensorboard=False,
+                    log_params=False, no_bucketing=False)
+
 
 def to_np(x):
     return x.data.cpu().numpy()
+
 
 class AverageMeter(object):
     """Computes and stores the average and current value"""
@@ -76,6 +80,7 @@ class AverageMeter(object):
         self.sum += val * n
         self.count += n
         self.avg = self.sum / self.count
+
 
 def main():
     args = parser.parse_args()
@@ -171,8 +176,9 @@ def main():
         if args.visdom and \
                         package['loss_results'] is not None and start_epoch > 0:  # Add previous scores to visdom graph
             epoch = start_epoch
-            loss_results[0:epoch], cer_results[0:epoch], wer_results[0:epoch] = package['loss_results'], package['cer_results'], package[
-                'wer_results']
+            loss_results[0:epoch], cer_results[0:epoch], wer_results[0:epoch] = package['loss_results'], package[
+                'cer_results'], package[
+                                                                                    'wer_results']
             x_axis = epochs[0:epoch]
             y_axis = [loss_results[0:epoch], wer_results[0:epoch], cer_results[0:epoch]]
             for x in range(len(viz_windows)):
@@ -181,7 +187,8 @@ def main():
                     Y=y_axis[x],
                     opts=opts[x],
                 )
-        if args.tensorboard and package['loss_results'] is not None and start_epoch > 0:  # Add previous scores to tensorboard logs
+        if args.tensorboard and package[
+            'loss_results'] is not None and start_epoch > 0:  # Add previous scores to tensorboard logs
             epoch = start_epoch
             loss_results, cer_results, wer_results = package['loss_results'], package['cer_results'], package[
                 'wer_results']
@@ -192,7 +199,7 @@ def main():
                     'Avg CER': cer_results[i]
                 }
                 for tag, val in info.items():
-                    logger.scalar_summary(tag, val, i+1)
+                    logger.scalar_summary(tag, val, i + 1)
     else:
         avg_loss = 0
         start_epoch = 0
@@ -265,7 +272,8 @@ def main():
             if args.checkpoint_per_batch > 0 and i > 0 and (i + 1) % args.checkpoint_per_batch == 0:
                 file_path = '%s/deepspeech_checkpoint_epoch_%d_iter_%d.pth.tar' % (save_folder, epoch + 1, i + 1)
                 print("Saving checkpoint model to %s" % file_path)
-                torch.save(DeepSpeech.serialize(model, optimizer=optimizer, epoch=epoch, iteration=i, loss_results=loss_results,
+                torch.save(DeepSpeech.serialize(model, optimizer=optimizer, epoch=epoch, iteration=i,
+                                                loss_results=loss_results,
                                                 wer_results=wer_results, cer_results=cer_results, avg_loss=avg_loss),
                            file_path)
             del loss
@@ -277,7 +285,7 @@ def main():
             epoch + 1, loss=avg_loss))
 
         start_iter = 0  # Reset start iteration for next epoch
-        total_cer, total_wer= 0, 0
+        total_cer, total_wer = 0, 0
         model.eval()
         for i, (data) in enumerate(test_loader):  # test
             inputs, targets, input_percentages, target_sizes = data
@@ -326,8 +334,8 @@ def main():
             wer_results[epoch] = wer
             cer_results[epoch] = cer
             # epoch += 1
-            x_axis = epochs[0:epoch+1]
-            y_axis = [loss_results[0:epoch+1], wer_results[0:epoch+1], cer_results[0:epoch+1]]
+            x_axis = epochs[0:epoch + 1]
+            y_axis = [loss_results[0:epoch + 1], wer_results[0:epoch + 1], cer_results[0:epoch + 1]]
             for x in range(len(viz_windows)):
                 if viz_windows[x] is None:
                     viz_windows[x] = viz.line(
@@ -352,13 +360,13 @@ def main():
                 'Avg CER': cer
             }
             for tag, val in info.items():
-                logger.scalar_summary(tag, val, epoch+1)
+                logger.scalar_summary(tag, val, epoch + 1)
             if args.log_params:
                 for tag, value in model.named_parameters():
                     tag = tag.replace('.', '/')
-                    logger.histo_summary(tag, to_np(value), epoch+1)
-                    if value.grad is not None: # Condition inserted because batch_norm RNN_0 weights.grad and bias.grad are None. Check why
-                        logger.histo_summary(tag+'/grad', to_np(value.grad), epoch+1)
+                    logger.histo_summary(tag, to_np(value), epoch + 1)
+                    if value.grad is not None:  # Condition inserted because batch_norm RNN_0 weights.grad and bias.grad are None. Check why
+                        logger.histo_summary(tag + '/grad', to_np(value.grad), epoch + 1)
         if args.checkpoint:
             file_path = '%s/deepspeech_%d.pth.tar' % (save_folder, epoch + 1)
             torch.save(DeepSpeech.serialize(model, optimizer=optimizer, epoch=epoch, loss_results=loss_results,
@@ -371,11 +379,11 @@ def main():
         print('Learning rate annealed to: {lr:.6f}'.format(lr=optim_state['param_groups'][0]['lr']))
 
         avg_loss = 0
-        if args.bucketing and epoch == 0:
-            print("Switching to bucketing")
+        if not args.no_bucketing and epoch == 0:
+            print("Switching to bucketing sampler for following epochs")
             train_dataset = SpectrogramDatasetWithLength(audio_conf=audio_conf, manifest_filepath=args.train_manifest,
-                                               labels=labels,
-                                               normalize=True, augment=args.augment)
+                                                         labels=labels,
+                                                         normalize=True, augment=args.augment)
             sampler = BucketingSampler(train_dataset)
             train_loader.sampler = sampler
 

--- a/train.py
+++ b/train.py
@@ -125,7 +125,6 @@ def main():
 
     with open(args.labels_path) as label_file:
         labels = str(''.join(json.load(label_file)))
-
     audio_conf = dict(sample_rate=args.sample_rate,
                       window_size=args.window_size,
                       window_stride=args.window_stride,
@@ -269,6 +268,8 @@ def main():
                 torch.save(DeepSpeech.serialize(model, optimizer=optimizer, epoch=epoch, iteration=i, loss_results=loss_results,
                                                 wer_results=wer_results, cer_results=cer_results, avg_loss=avg_loss),
                            file_path)
+            del loss
+            del out
         avg_loss /= len(train_loader)
 
         print('Training Summary Epoch: [{0}]\t'
@@ -309,6 +310,7 @@ def main():
 
             if args.cuda:
                 torch.cuda.synchronize()
+            del out
         wer = total_wer / len(test_loader.dataset)
         cer = total_cer / len(test_loader.dataset)
         wer *= 100


### PR DESCRIPTION
I think it might be a solution to #30. Instead of random sampling, we could split firstly the whole dataset into several buckets depending on the length of the utterance and then randomly sample from each of the buckets. As a result, we can have batches with similar length utterances.

