### PR TITLE
Add beam search

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ cd audio
 python setup.py install
 ```
 
+If you want decoding to support beam search with an optional language model, install pytorch-ctc:
+```
+git clone --recursive https://github.com/ryanleary/pytorch-ctc.git
+cd pytorch-ctc
+pip install -r requirements.txt
+
+# build the extension and install python package (requires gcc-5 or later)
+CC=/path/to/gcc-5 CXX=/path/to/g++-5 python setup.py install
+```
+
 Finally:
 ```
 pip install -r requirements.txt
@@ -219,6 +229,17 @@ An example script to output a prediction has been provided:
 ```
 python predict.py --model_path models/deepspeech.pth.tar --audio_path /path/to/audio.wav
 ```
+
+### Alternate Decoders
+By default, `test.py` and `predict.py` use a `GreedyDecoder` which picks the highest-likelihood output label at each timestep. Repeated and blank symbols are then filtered to give the final output.
+
+A beam search decoder can optionally be used with the installation of the `pytorch-ctc` library as described in the Installation section. The `test` and `predict` scripts have a `--decoder` argument. To use the beam decoder, add `--decoder beam`. The beam decoder enables additional decoding parameters:
+- **beam_width** how many beams to consider at each timestep
+- **lm_path** optional binary KenLM language model to use for decoding
+- **trie_path** trie describing lexicon. required if `lm_path` is supplied
+- **lm_alpha** weight for language model
+- **lm_beta1** bonus weight for words
+- **lm_beta2** bonus weight for in-vocabulary words
 
 ## Acknowledgements
 

--- a/decoder.py
+++ b/decoder.py
@@ -142,7 +142,7 @@ class BeamCTCDecoder(Decoder):
             raise ImportError("BeamCTCDecoder requires pytorch_ctc package.")
 
         self._decoder = CTCBD(scorer, labels, top_paths=top_paths, beam_width=beam_width,
-                              blank_index=blank_index, space_index=space_index, merge_repeated=True)
+                              blank_index=blank_index, space_index=space_index, merge_repeated=False)
 
 
     def decode(self, probs, sizes=None):

--- a/decoder.py
+++ b/decoder.py
@@ -138,7 +138,7 @@ class BeamCTCDecoder(Decoder):
         self._ctc = pytorch_ctc
 
     def decode(self, probs, sizes=None):
-        out, conf, seq_len = self._ctc.beam_decode(probs, sizes, top_paths=self._top_n,
+        out, conf, seq_len = self._ctc.beam_decode(probs.cpu(), sizes.cpu(), top_paths=self._top_n,
                                                    beam_width=self._beam_width, merge_repeated=False)
         # TODO: support returning multiple paths
         strings = self.convert_to_strings(out[0], sizes=seq_len[0])

--- a/decoder.py
+++ b/decoder.py
@@ -138,7 +138,8 @@ class BeamCTCDecoder(Decoder):
         self._ctc = pytorch_ctc
 
     def decode(self, probs, sizes=None):
-        out, conf, seq_len = self._ctc.beam_decode(probs.cpu(), sizes.cpu(), top_paths=self._top_n,
+        sizes = sizes.cpu() if sizes is not None else None
+        out, conf, seq_len = self._ctc.beam_decode(probs.cpu(), sizes, top_paths=self._top_n,
                                                    beam_width=self._beam_width, merge_repeated=False)
         # TODO: support returning multiple paths
         strings = self.convert_to_strings(out[0], sizes=seq_len[0])

--- a/decoder.py
+++ b/decoder.py
@@ -42,7 +42,7 @@ class Decoder(object):
         """Given a list of numeric sequences, returns the corresponding strings"""
         strings = []
         for x in xrange(len(sequences)):
-            seq_len = sizes[x][0] if sizes is not None else len(sequences[x])
+            seq_len = sizes[x] if sizes is not None else len(sequences[x])
             string = self._convert_to_string(sequences[x], seq_len)
             strings.append(string)
         return strings
@@ -140,7 +140,8 @@ class BeamCTCDecoder(Decoder):
     def decode(self, probs, sizes=None):
         out, conf, seq_len = self._ctc.beam_decode(probs, sizes, top_paths=self._top_n,
                                                    beam_width=self._beam_width, merge_repeated=False)
-        strings = self.convert_to_strings(out[0], sizes=seq_len)
+        # TODO: support returning multiple paths
+        strings = self.convert_to_strings(out[0], sizes=seq_len[0])
         return self.process_strings(strings)
 
 class GreedyDecoder(Decoder):
@@ -156,6 +157,5 @@ class GreedyDecoder(Decoder):
             strings: sequences of the model's best guess for the transcription on inputs
         """
         _, max_probs = torch.max(probs.transpose(0, 1), 2)
-        size_data = sizes.data if sizes is not None else None
-        strings = self.convert_to_strings(max_probs.view(max_probs.size(0), max_probs.size(1)), size_data)
+        strings = self.convert_to_strings(max_probs.view(max_probs.size(0), max_probs.size(1)), sizes)
         return self.process_strings(strings, remove_repetitions=True)

--- a/decoder.py
+++ b/decoder.py
@@ -17,8 +17,13 @@
 
 import Levenshtein as Lev
 import torch
+from enum import Enum
 from six.moves import xrange
-
+try:
+    from pytorch_ctc import CTCBeamDecoder as CTCBD
+    from pytorch_ctc import Scorer, KenLMScorer
+except ImportError:
+    print("warn: pytorch_ctc unavailable. Only greedy decoding is supported.")
 
 class Decoder(object):
     """
@@ -127,7 +132,7 @@ class Decoder(object):
 
 
 class BeamCTCDecoder(Decoder):
-    def __init__(self, labels, beam_width=20, top_paths=1, blank_index=0, space_index=28):
+    def __init__(self, labels, scorer, beam_width=20, top_paths=1, blank_index=0, space_index=28):
         super(BeamCTCDecoder, self).__init__(labels, blank_index=blank_index, space_index=space_index)
         self._beam_width = beam_width
         self._top_n = top_paths
@@ -135,12 +140,15 @@ class BeamCTCDecoder(Decoder):
             import pytorch_ctc
         except ImportError:
             raise ImportError("BeamCTCDecoder requires pytorch_ctc package.")
-        self._ctc = pytorch_ctc
+
+        self._decoder = CTCBD(scorer, labels, top_paths=top_paths, beam_width=beam_width,
+                              blank_index=blank_index, space_index=space_index, merge_repeated=True)
+
 
     def decode(self, probs, sizes=None):
         sizes = sizes.cpu() if sizes is not None else None
-        out, conf, seq_len = self._ctc.beam_decode(probs.cpu(), sizes, top_paths=self._top_n,
-                                                   beam_width=self._beam_width, merge_repeated=False)
+        out, conf, seq_len = self._decoder.decode(probs.cpu(), sizes)
+
         # TODO: support returning multiple paths
         strings = self.convert_to_strings(out[0], sizes=seq_len[0])
         return self.process_strings(strings)

--- a/generate_lm_trie.py
+++ b/generate_lm_trie.py
@@ -1,0 +1,21 @@
+import pytorch_ctc
+import json
+import argparse
+
+parser = argparse.ArgumentParser(description='LM Trie Generation')
+parser.add_argument('--labels', help='path to label json file', default='labels.json')
+parser.add_argument('--dictionary', help='path to text dictionary (one word per line)', default='vocab.txt')
+parser.add_argument('--kenlm', help='path to binary kenlm language model', default="lm.kenlm")
+parser.add_argument('--trie', help='path of trie to output', default='vocab.trie')
+
+def main():
+    args = parser.parse_args()
+    with open(args.labels, "r") as fh:
+        label_data = json.load(fh)
+
+    labels = ''.join(label_data)
+
+    pytorch_ctc.generate_lm_trie(args.dictionary, args.kenlm, args.trie, labels, labels.index('_'), labels.index(' '))
+
+if __name__ == '__main__':
+    main()

--- a/model.py
+++ b/model.py
@@ -36,12 +36,15 @@ class SequenceWise(nn.Module):
         tmpstr += ')'
         return tmpstr
 
-class BatchSoftmax(nn.Module):
+
+class InferenceBatchSoftmax(nn.Module):
     def forward(self, input_):
-        output_ = input_.transpose(0,1)
-        batch_size = output_.size()[0]
-        output_ = torch.stack([F.log_softmax(output_[i]) for i in range(batch_size)], 0)
-        return output_
+        if not self.training:
+            batch_size = input_.size()[0]
+            return torch.stack([F.log_softmax(input_[i]) for i in range(batch_size)], 0)
+        else:
+            return input_
+
 
 class BatchRNN(nn.Module):
     def __init__(self, input_size, hidden_size, rnn_type=nn.LSTM, bidirectional=False, batch_norm=True):
@@ -77,7 +80,6 @@ class DeepSpeech(nn.Module):
         self._rnn_type = rnn_type
         self._audio_conf = audio_conf or {}
         self._labels = labels
-        self._softmax = BatchSoftmax()
 
         sample_rate = self._audio_conf.get("sample_rate", 16000)
         window_size = self._audio_conf.get("window_size", 0.02)
@@ -113,6 +115,7 @@ class DeepSpeech(nn.Module):
         self.fc = nn.Sequential(
             SequenceWise(fully_connected),
         )
+        self.softmax = InferenceBatchSoftmax()
 
     def forward(self, x):
         x = self.conv(x)
@@ -124,8 +127,8 @@ class DeepSpeech(nn.Module):
         x = self.rnns(x)
 
         x = self.fc(x)
-        if not self.training:
-            x = self._softmax(x)
+        x = x.transpose(0, 1)
+        x = self.softmax(x)
         return x
 
     @classmethod

--- a/predict.py
+++ b/predict.py
@@ -6,7 +6,7 @@ import torch
 from torch.autograd import Variable
 
 from data.data_loader import SpectrogramParser
-from decoder import GreedyDecoder, BeamCTCDecoder
+from decoder import GreedyDecoder, BeamCTCDecoder, Scorer, KenLMScorer
 from model import DeepSpeech
 
 parser = argparse.ArgumentParser(description='DeepSpeech prediction')
@@ -18,6 +18,11 @@ parser.add_argument('--cuda', action="store_true", help='Use cuda to test model'
 parser.add_argument('--decoder', default="greedy", choices=["greedy", "beam"], type=str, help="Decoder to use")
 beam_args = parser.add_argument_group("Beam Decode Options", "Configurations options for the CTC Beam Search decoder")
 beam_args.add_argument('--beam_width', default=10, type=int, help='Beam width to use')
+beam_args.add_argument('--lm_path', default=None, type=str, help='Path to an (optional) kenlm language model for use with beam search (req\'d with trie)')
+beam_args.add_argument('--trie_path', default=None, type=str, help='Path to an (optional) trie dictionary for use with beam search (req\'d with LM)')
+beam_args.add_argument('--lm_alpha', default=0.8, type=float, help='Language model weight')
+beam_args.add_argument('--lm_beta1', default=1, type=float, help='Language model word bonus (all words)')
+beam_args.add_argument('--lm_beta2', default=1, type=float, help='Language model word bonus (IV words)')
 args = parser.parse_args()
 
 if __name__ == '__main__':
@@ -28,9 +33,17 @@ if __name__ == '__main__':
     audio_conf = DeepSpeech.get_audio_conf(model)
 
     if args.decoder == "beam":
-        decoder = BeamCTCDecoder(labels, beam_width=args.beam_width, top_paths=1, blank_index=labels.index('_'))
+        scorer = None
+        if args.lm_path is not None:
+            scorer = KenLMScorer(labels, args.lm_path, args.trie_path)
+            scorer.set_lm_weight(args.lm_alpha)
+            scorer.set_word_weight(args.lm_beta1)
+            scorer.set_valid_word_weight(args.lm_beta2)
+        else:
+            scorer = Scorer()
+        decoder = BeamCTCDecoder(labels, scorer, beam_width=args.beam_width, top_paths=1, space_index=labels.index(' '), blank_index=labels.index('_'))
     else:
-        decoder = GreedyDecoder(labels, blank_index=labels.index('_'))
+        decoder = GreedyDecoder(labels, space_index=labels.index(' '), blank_index=labels.index('_'))
 
     parser = SpectrogramParser(audio_conf, normalize=True)
 

--- a/predict.py
+++ b/predict.py
@@ -1,10 +1,12 @@
 import argparse
+import sys
+import time
 
 import torch
 from torch.autograd import Variable
 
 from data.data_loader import SpectrogramParser
-from decoder import ArgMaxDecoder
+from decoder import GreedyDecoder, BeamCTCDecoder
 from model import DeepSpeech
 
 parser = argparse.ArgumentParser(description='DeepSpeech prediction')
@@ -13,6 +15,9 @@ parser.add_argument('--model_path', default='models/deepspeech_final.pth.tar',
 parser.add_argument('--audio_path', default='audio.wav',
                     help='Audio file to predict on')
 parser.add_argument('--cuda', action="store_true", help='Use cuda to test model')
+parser.add_argument('--decoder', default="greedy", choices=["greedy", "beam"], type=str, help="Decoder to use")
+beam_args = parser.add_argument_group("Beam Decode Options", "Configurations options for the CTC Beam Search decoder")
+beam_args.add_argument('--beam_width', default=10, type=int, help='Beam width to use')
 args = parser.parse_args()
 
 if __name__ == '__main__':
@@ -22,11 +27,20 @@ if __name__ == '__main__':
     labels = DeepSpeech.get_labels(model)
     audio_conf = DeepSpeech.get_audio_conf(model)
 
-    decoder = ArgMaxDecoder(labels)
+    if args.decoder == "beam":
+        decoder = BeamCTCDecoder(labels, beam_width=args.beam_width, top_paths=1, blank_index=labels.index('_'))
+    else:
+        decoder = GreedyDecoder(labels, blank_index=labels.index('_'))
+
     parser = SpectrogramParser(audio_conf, normalize=True)
+
+    t0 = time.time()
     spect = parser.parse_audio(args.audio_path).contiguous()
     spect = spect.view(1, 1, spect.size(0), spect.size(1))
     out = model(Variable(spect, volatile=True))
     out = out.transpose(0, 1)  # TxNxH
     decoded_output = decoder.decode(out.data)
+    t1 = time.time()
+
     print(decoded_output[0])
+    print("Decoded {0:.2f} seconds of audio in {1:.2f} seconds".format(spect.size(3)*audio_conf['window_stride'], t1-t0), file=sys.stderr)

--- a/test.py
+++ b/test.py
@@ -5,7 +5,7 @@ import torch
 from torch.autograd import Variable
 
 from data.data_loader import SpectrogramDataset, AudioDataLoader
-from decoder import ArgMaxDecoder
+from decoder import GreedyDecoder, BeamCTCDecoder
 from model import DeepSpeech
 
 parser = argparse.ArgumentParser(description='DeepSpeech prediction')
@@ -16,6 +16,9 @@ parser.add_argument('--test_manifest', metavar='DIR',
                     help='path to validation manifest csv', default='data/test_manifest.csv')
 parser.add_argument('--batch_size', default=20, type=int, help='Batch size for training')
 parser.add_argument('--num_workers', default=4, type=int, help='Number of workers used in dataloading')
+parser.add_argument('--decoder', default="greedy", choices=["greedy", "beam"], type=str, help="Decoder to use")
+beam_args = parser.add_argument_group("Beam Decode Options", "Configurations options for the CTC Beam Search decoder")
+beam_args.add_argument('--beam_width', default=10, type=int, help='Beam width to use')
 args = parser.parse_args()
 
 if __name__ == '__main__':
@@ -24,7 +27,11 @@ if __name__ == '__main__':
 
     labels = DeepSpeech.get_labels(model)
     audio_conf = DeepSpeech.get_audio_conf(model)
-    decoder = ArgMaxDecoder(labels)
+
+    if args.decoder == "beam":
+        decoder = BeamCTCDecoder(labels, beam_width=args.beam_width, top_paths=1, blank_index=labels.index('_'))
+    else:
+        decoder = GreedyDecoder(labels, blank_index=labels.index('_'))
 
     test_dataset = SpectrogramDataset(audio_conf=audio_conf, manifest_filepath=args.test_manifest, labels=labels,
                                       normalize=True)
@@ -49,7 +56,7 @@ if __name__ == '__main__':
         out = model(inputs)
         out = out.transpose(0, 1)  # TxNxH
         seq_length = out.size(0)
-        sizes = Variable(input_percentages.mul_(int(seq_length)).int(), volatile=True)
+        sizes = input_percentages.mul_(int(seq_length)).int()
 
         decoded_output = decoder.decode(out.data, sizes)
         target_strings = decoder.process_strings(decoder.convert_to_strings(split_targets))

--- a/test.py
+++ b/test.py
@@ -5,7 +5,7 @@ import torch
 from torch.autograd import Variable
 
 from data.data_loader import SpectrogramDataset, AudioDataLoader
-from decoder import GreedyDecoder, BeamCTCDecoder
+from decoder import GreedyDecoder, BeamCTCDecoder, Scorer, KenLMScorer
 from model import DeepSpeech
 
 parser = argparse.ArgumentParser(description='DeepSpeech prediction')
@@ -19,6 +19,11 @@ parser.add_argument('--num_workers', default=4, type=int, help='Number of worker
 parser.add_argument('--decoder', default="greedy", choices=["greedy", "beam"], type=str, help="Decoder to use")
 beam_args = parser.add_argument_group("Beam Decode Options", "Configurations options for the CTC Beam Search decoder")
 beam_args.add_argument('--beam_width', default=10, type=int, help='Beam width to use')
+beam_args.add_argument('--lm_path', default=None, type=str, help='Path to an (optional) kenlm language model for use with beam search (req\'d with trie)')
+beam_args.add_argument('--trie_path', default=None, type=str, help='Path to an (optional) trie dictionary for use with beam search (req\'d with LM)')
+beam_args.add_argument('--lm_alpha', default=0.8, type=float, help='Language model weight')
+beam_args.add_argument('--lm_beta1', default=1, type=float, help='Language model word bonus (all words)')
+beam_args.add_argument('--lm_beta2', default=1, type=float, help='Language model word bonus (IV words)')
 args = parser.parse_args()
 
 if __name__ == '__main__':
@@ -29,9 +34,17 @@ if __name__ == '__main__':
     audio_conf = DeepSpeech.get_audio_conf(model)
 
     if args.decoder == "beam":
-        decoder = BeamCTCDecoder(labels, beam_width=args.beam_width, top_paths=1, blank_index=labels.index('_'))
+        scorer = None
+        if args.lm_path is not None:
+            scorer = KenLMScorer(labels, args.lm_path, args.trie_path)
+            scorer.set_lm_weight(args.lm_alpha)
+            scorer.set_word_weight(args.lm_beta1)
+            scorer.set_valid_word_weight(args.lm_beta2)
+        else:
+            scorer = Scorer()
+        decoder = BeamCTCDecoder(labels, scorer, beam_width=args.beam_width, top_paths=1, space_index=labels.index(' '), blank_index=labels.index('_'))
     else:
-        decoder = GreedyDecoder(labels, blank_index=labels.index('_'))
+        decoder = GreedyDecoder(labels, space_index=labels.index(' '), blank_index=labels.index('_'))
 
     test_dataset = SpectrogramDataset(audio_conf=audio_conf, manifest_filepath=args.test_manifest, labels=labels,
                                       normalize=True)

--- a/train.py
+++ b/train.py
@@ -10,7 +10,7 @@ from warpctc_pytorch import CTCLoss
 
 from data.bucketing_sampler import BucketingSampler, SpectrogramDatasetWithLength
 from data.data_loader import AudioDataLoader, SpectrogramDataset
-from decoder import ArgMaxDecoder
+from decoder import GreedyDecoder
 from model import DeepSpeech, supported_rnns
 
 parser = argparse.ArgumentParser(description='DeepSpeech training')
@@ -304,7 +304,7 @@ def main():
             out = model(inputs)
             out = out.transpose(0, 1)  # TxNxH
             seq_length = out.size(0)
-            sizes = Variable(input_percentages.mul_(int(seq_length)).int(), volatile=True)
+            sizes = input_percentages.mul_(int(seq_length)).int()
 
             decoded_output = decoder.decode(out.data, sizes)
             target_strings = decoder.process_strings(decoder.convert_to_strings(split_targets))

--- a/train.py
+++ b/train.py
@@ -153,7 +153,7 @@ def main():
     parameters = model.parameters()
     optimizer = torch.optim.SGD(parameters, lr=args.lr,
                                 momentum=args.momentum, nesterov=True)
-    decoder = ArgMaxDecoder(labels)
+    decoder = GreedyDecoder(labels)
 
     if args.continue_from:
         print("Loading checkpoint model %s" % args.continue_from)


### PR DESCRIPTION
This is a WIP integration of beam search based on my port of the ctc beam decoder in tensorflow. Will address #86. 

 Remaining:
- [x] additional testing
- [x] add optional dictionary constraint
- [x] add optional lm functionality
- [x] Add documentation
- [x] Update requirements.txt

If you want to test it out, you will need to manually install my pytorch_ctc bindings: https://github.com/ryanleary/pytorch-ctc