### PR TITLE
Refactor model output to reflect its type

### DIFF
--- a/model.py
+++ b/model.py
@@ -37,7 +37,7 @@ class SequenceWise(nn.Module):
         return tmpstr
 
 
-class InferenceBatchSoftmax(nn.Module):
+class InferenceBatchLogSoftmax(nn.Module):
     def forward(self, input_):
         if not self.training:
             batch_size = input_.size()[0]
@@ -115,7 +115,7 @@ class DeepSpeech(nn.Module):
         self.fc = nn.Sequential(
             SequenceWise(fully_connected),
         )
-        self.softmax = InferenceBatchSoftmax()
+        self.inference_log_softmax = InferenceBatchLogSoftmax()
 
     def forward(self, x):
         x = self.conv(x)
@@ -128,7 +128,8 @@ class DeepSpeech(nn.Module):
 
         x = self.fc(x)
         x = x.transpose(0, 1)
-        x = self.softmax(x)
+        # identity in training mode, logsoftmax in eval mode
+        x = self.inference_log_softmax(x)
         return x
 
     @classmethod


### PR DESCRIPTION
Rename the `softmax` into `inference_log_softmax` to emphasize that the output is linear in training time.

Concerns #121.