### PR TITLE
Add LM tuning functionality & detailed transcription output

### DIFF
--- a/decoder.py
+++ b/decoder.py
@@ -151,6 +151,10 @@ class BeamCTCDecoder(Decoder):
 
 
 class GreedyDecoder(Decoder):
+    def __init__(self, labels, blank_index=0, space_index=28):
+        super(GreedyDecoder, self).__init__(labels, blank_index=blank_index, space_index=space_index)
+        self._top_n = 1
+
     def convert_to_strings(self, sequences, sizes=None, remove_repetitions=False, return_offsets=False):
         """Given a list of numeric sequences, returns the corresponding strings"""
         strings = []

--- a/model.py
+++ b/model.py
@@ -215,6 +215,18 @@ class DeepSpeech(nn.Module):
         model_is_cuda = next(model.parameters()).is_cuda
         return model.module._audio_conf if model_is_cuda else model._audio_conf
 
+    @staticmethod
+    def get_meta(model):
+        model_is_cuda = next(model.parameters()).is_cuda
+        m = model.module if model_is_cuda else model
+        meta = {
+            "version": m._version,
+            "hidden_size": m._hidden_size,
+            "hidden_layers": m._hidden_layers,
+            "rnn_type": supported_rnns_inv[m._rnn_type]
+        }
+        return meta
+
 
 if __name__ == '__main__':
     import os.path

--- a/test.py
+++ b/test.py
@@ -1,5 +1,6 @@
 import argparse
 
+import numpy as np
 from torch.autograd import Variable
 from tqdm import tqdm
 
@@ -16,8 +17,10 @@ parser.add_argument('--test_manifest', metavar='DIR',
                     help='path to validation manifest csv', default='data/test_manifest.csv')
 parser.add_argument('--batch_size', default=20, type=int, help='Batch size for training')
 parser.add_argument('--num_workers', default=4, type=int, help='Number of workers used in dataloading')
-parser.add_argument('--decoder', default="greedy", choices=["greedy", "beam"], type=str, help="Decoder to use")
+parser.add_argument('--decoder', default="greedy", choices=["greedy", "beam", "none"], type=str, help="Decoder to use")
 parser.add_argument('--verbose', action="store_true", help="print out decoded output and error of each sample")
+no_decoder_args = parser.add_argument_group("No Decoder Options", "Configuration options for when no decoder is specified")
+no_decoder_args.add_argument('--output_path', default=None, type=str, "Where to save raw acoustic output")
 beam_args = parser.add_argument_group("Beam Decode Options", "Configurations options for the CTC Beam Search decoder")
 beam_args.add_argument('--beam_width', default=10, type=int, help='Beam width to use')
 beam_args.add_argument('--lm_path', default=None, type=str,
@@ -46,14 +49,17 @@ if __name__ == '__main__':
                                  blank_index=labels.index('_'), lm_path=args.lm_path,
                                  trie_path=args.trie_path, lm_alpha=args.lm_alpha, lm_beta=args.lm_beta,
                                  label_size=args.label_size, label_margin=args.label_margin)
-    else:
+    elif args.decoder == "greedy":
         decoder = GreedyDecoder(labels, space_index=labels.index(' '), blank_index=labels.index('_'))
+    else:
+        decoder = None
     target_decoder = GreedyDecoder(labels, space_index=labels.index(' '), blank_index=labels.index('_'))
     test_dataset = SpectrogramDataset(audio_conf=audio_conf, manifest_filepath=args.test_manifest, labels=labels,
                                       normalize=True)
     test_loader = AudioDataLoader(test_dataset, batch_size=args.batch_size,
                                   num_workers=args.num_workers)
     total_cer, total_wer = 0, 0
+    output_data = []
     for i, (data) in tqdm(enumerate(test_loader), total=len(test_loader)):
         inputs, targets, input_percentages, target_sizes = data
 
@@ -74,6 +80,11 @@ if __name__ == '__main__':
         seq_length = out.size(0)
         sizes = input_percentages.mul_(int(seq_length)).int()
 
+        if decoder is None:
+            # add output to data array, and continue
+            output_data.append((out.data.numpy(), sizes.numpy()))
+            continue
+
         decoded_output, _, _, _ = decoder.decode(out.data, sizes)
         target_strings = target_decoder.convert_to_strings(split_targets)
         wer, cer = 0, 0
@@ -89,9 +100,12 @@ if __name__ == '__main__':
         total_cer += cer
         total_wer += wer
 
-    wer = total_wer / len(test_loader.dataset)
-    cer = total_cer / len(test_loader.dataset)
+    if decoder is not None:
+        wer = total_wer / len(test_loader.dataset)
+        cer = total_cer / len(test_loader.dataset)
 
-    print('Test Summary \t'
-          'Average WER {wer:.3f}\t'
-          'Average CER {cer:.3f}\t'.format(wer=wer * 100, cer=cer * 100))
+        print('Test Summary \t'
+              'Average WER {wer:.3f}\t'
+              'Average CER {cer:.3f}\t'.format(wer=wer * 100, cer=cer * 100))
+    else:
+        np.save(args.output_path, output_data)

--- a/test.py
+++ b/test.py
@@ -20,7 +20,7 @@ parser.add_argument('--num_workers', default=4, type=int, help='Number of worker
 parser.add_argument('--decoder', default="greedy", choices=["greedy", "beam", "none"], type=str, help="Decoder to use")
 parser.add_argument('--verbose', action="store_true", help="print out decoded output and error of each sample")
 no_decoder_args = parser.add_argument_group("No Decoder Options", "Configuration options for when no decoder is specified")
-no_decoder_args.add_argument('--output_path', default=None, type=str, "Where to save raw acoustic output")
+no_decoder_args.add_argument('--output_path', default=None, type=str, help="Where to save raw acoustic output")
 beam_args = parser.add_argument_group("Beam Decode Options", "Configurations options for the CTC Beam Search decoder")
 beam_args.add_argument('--beam_width', default=10, type=int, help='Beam width to use')
 beam_args.add_argument('--lm_path', default=None, type=str,
@@ -82,7 +82,7 @@ if __name__ == '__main__':
 
         if decoder is None:
             # add output to data array, and continue
-            output_data.append((out.data.numpy(), sizes.numpy()))
+            output_data.append((out.data.cpu().numpy(), sizes.numpy()))
             continue
 
         decoded_output, _, _, _ = decoder.decode(out.data, sizes)

--- a/transcribe.py
+++ b/transcribe.py
@@ -1,4 +1,6 @@
 import argparse
+import warnings
+warnings.simplefilter('ignore')
 
 from decoder import GreedyDecoder
 
@@ -6,6 +8,9 @@ from torch.autograd import Variable
 
 from data.data_loader import SpectrogramParser
 from model import DeepSpeech
+import os.path
+import numpy as np
+import json
 
 parser = argparse.ArgumentParser(description='DeepSpeech transcription')
 parser.add_argument('--model_path', default='models/deepspeech_final.pth.tar',
@@ -21,14 +26,68 @@ beam_args.add_argument('--lm_path', default=None, type=str,
                        help='Path to an (optional) kenlm language model for use with beam search (req\'d with trie)')
 beam_args.add_argument('--trie_path', default=None, type=str,
                        help='Path to an (optional) trie dictionary for use with beam search (req\'d with LM)')
-beam_args.add_argument('--lm_alpha', default=0.8, type=float, help='Language model weight')
-beam_args.add_argument('--lm_beta', default=1, type=float, help='Language model word bonus (all words)')
+beam_args.add_argument('--lm_alpha', default=1.9, type=float, help='Language model weight')
+beam_args.add_argument('--lm_beta', default=0, type=float, help='Language model word bonus (all words)')
 beam_args.add_argument('--label_size', default=0, type=int, help='Label selection size controls how many items in '
                                                                  'each beam are passed through to the beam scorer')
 beam_args.add_argument('--label_margin', default=-1, type=float, help='Controls difference between minimal input score '
                                                                       'for an item to be passed to the beam scorer.')
 parser.add_argument('--offsets', dest='offsets', action='store_true', help='Returns time offset information')
+parser.add_argument('--word_json', dest='word_json', action='store_true', help='Return word-level results as a json object')
 args = parser.parse_args()
+
+def word_decode(decoder, data, time_div=50, window=5, model=None):
+    strings, aligns, conf, char_probs = decoder.decode(data)
+
+    results = {
+        "one_best": "",
+        "num_paths": decoder._top_n,
+        "top_paths": [],
+        "_meta": {
+            "acoustic_model": {
+                "name": os.path.basename(args.model_path),
+                **DeepSpeech.get_meta(model)
+            },
+            "language_model": {
+                "name": os.path.basename(args.lm_path) if args.lm_path else None,
+                "dict": os.path.basename(args.trie_path) if args.trie_path else None
+            },
+            "decoder": {
+                "lm": args.lm_path is not None,
+                "dict": args.trie_path is not None,
+                "alpha": args.lm_alpha if args.lm_path is not None else None,
+                "beta": args.lm_beta if args.lm_path is not None else None,
+                "type": args.decoder,
+                "label_size": args.label_size,
+                "label_margin": args.label_margin
+            }
+        }
+    }
+
+    for pi in range(len(strings)):
+        for i in range(len(strings[pi])):
+            path = {"rank": pi, "conf": float(conf[pi][i]), "tokens": []}
+            word = ''
+            word_prob = 0.0
+            start_idx = -1
+            for idx, c in enumerate(strings[pi][i]):
+                if c == ' ' and word != '':
+                    start_align = aligns[pi][i][start_idx]
+                    end_align = aligns[pi][i][idx-1]+window
+                    path['tokens'].append({"token": word, "start": start_align/time_div, "end": end_align/time_div, "conf": word_prob})
+                    word = ''
+                    start_idx = -1
+                else:
+                    if start_idx == -1:
+                        start_idx = idx
+                    word += c
+                    word_prob += char_probs[pi][i][idx]
+            if word != '':
+                path['tokens'].append({"token": word, "start": (aligns[pi][i][start_idx])/time_div, "end": (aligns[pi][i][len(strings[pi][i])-1]+window)/time_div, "conf": word_prob})
+        results['top_paths'].append(path)
+    if len(results['top_paths']) > 0:
+        results['one_best'] = " ".join([x['token'] for x in results['top_paths'][0]['tokens']])
+    return results
 
 if __name__ == '__main__':
     model = DeepSpeech.load_model(args.model_path, cuda=args.cuda)
@@ -54,8 +113,13 @@ if __name__ == '__main__':
     spect = spect.view(1, 1, spect.size(0), spect.size(1))
     out = model(Variable(spect, volatile=True))
     out = out.transpose(0, 1)  # TxNxH
-    decoded_output, decoded_offsets, confs, char_probs = decoder.decode(out.data)
-    for pi in range(args.top_paths):
-        print(decoded_output[pi][0])
-        if args.offsets:
-            print(decoded_offsets[pi][0])
+
+    if args.word_json:
+        results = word_decode(decoder, out.data, model=model, window=1/(10*audio_conf['window_size']), time_div=1/audio_conf['window_size'])
+        print(json.dumps(results))
+    else:
+        decoded_output, decoded_offsets, confs, char_probs = decoder.decode(out.data)
+        for pi in range(args.top_paths):
+            print(decoded_output[pi][0])
+            if args.offsets:
+                print(decoded_offsets[pi][0])

--- a/tune_decoder.py
+++ b/tune_decoder.py
@@ -1,0 +1,87 @@
+import argparse
+
+from torch.autograd import Variable
+from tqdm import tqdm
+
+from decoder import GreedyDecoder, BeamCTCDecoder
+
+from data.data_loader import SpectrogramDataset, AudioDataLoader
+from model import DeepSpeech
+
+parser = argparse.ArgumentParser(description='DeepSpeech transcription')
+parser.add_argument('--model_path', default='models/deepspeech_final.pth.tar',
+                    help='Path to model file created by training')
+parser.add_argument('--logits', default=None, type=str, help='Path to logits from test.py')
+parser.add_argument('--test_manifest', metavar='DIR',
+                    help='path to validation manifest csv', default='data/test_manifest.csv')
+parser.add_argument('--num_workers', default=4, type=int, help='Number of workers used in dataloading')
+beam_args = parser.add_argument_group("Beam Decode Options", "Configurations options for the CTC Beam Search decoder")
+beam_args.add_argument('--beam_width', default=10, type=int, help='Beam width to use')
+beam_args.add_argument('--lm_path', default=None, type=str,
+                       help='Path to an (optional) kenlm language model for use with beam search (req\'d with trie)')
+beam_args.add_argument('--trie_path', default=None, type=str,
+                       help='Path to an (optional) trie dictionary for use with beam search (req\'d with LM)')
+beam_args.add_argument('--lm_alpha_from', default=1, type=float, help='Language model weight start tuning')
+beam_args.add_argument('--lm_alpha_to', default=3.2, type=float, help='Language model weight end tuning')
+beam_args.add_argument('--lm_beta_from', default=0.0, type=float, help='Language model word bonus (all words) start tuning')
+beam_args.add_argument('--lm_beta_to', default=0.45, type=float, help='Language model word bonus (all words) end tuning')
+beam_args.add_argument('--lm_num_alphas', default=45, type=float, help='Number of alpha candidates for tuning')
+beam_args.add_argument('--lm_num_betas', default=8, type=float, help='Number of beta candidates for tuning')
+beam_args.add_argument('--label_size', default=0, type=int, help='Label selection size controls how many items in '
+                                                                 'each beam are passed through to the beam scorer')
+beam_args.add_argument('--label_margin', default=-1, type=float, help='Controls difference between minimal input score '
+                                                                      'for an item to be passed to the beam scorer.')
+args = parser.parse_args()
+
+def decode_dataset(logits, test_loader, lm_alpha, lm_beta, labels):
+    target_decoder = GreedyDecoder(labels, space_index=labels.index(' '), blank_index=labels.index('_'))
+    decoder = BeamCTCDecoder(labels, beam_width=args.beam_width, top_paths=1, space_index=labels.index(' '),
+                             blank_index=labels.index('_'), lm_path=args.lm_path,
+                             trie_path=args.trie_path, lm_alpha=lm_alpha, lm_beta=lm_beta,
+                             label_size=args.label_size, label_margin=args.label_margin)
+    total_cer, total_wer = 0, 0
+    for i, (data) in tqdm(enumerate(test_loader), total=len(test_loader)):
+        inputs, targets, input_percentages, target_sizes = data
+
+        # unflatten targets
+        split_targets = []
+        offset = 0
+        for size in target_sizes:
+            split_targets.append(targets[offset:offset + size])
+            offset += size
+
+        out = torch.from_numpy(logits[i][0])
+        sizes = torch.from_numpy(logits[i][1])
+
+        decoded_output, _, _, _ = decoder.decode(out.data, sizes)
+        target_strings = target_decoder.convert_to_strings(split_targets)
+        wer, cer = 0, 0
+        for x in range(len(target_strings)):
+            wer_inst = decoder.wer(decoded_output[0][x], target_strings[x]) / float(len(target_strings[x].split()))
+            cer_inst = decoder.cer(decoded_output[0][x], target_strings[x]) / float(len(target_strings[x]))
+            wer += wer_inst
+            cer += cer_inst
+        total_cer += cer
+        total_wer += wer
+
+    wer = total_wer / len(test_loader.dataset)
+    cer = total_cer / len(test_loader.dataset)
+
+    return (lm_alpha, lm_beta, wer, cer)
+
+
+if __name__ == '__main__':
+    model = DeepSpeech.load_model(args.model_path, cuda=args.cuda)
+    model.eval()
+
+    labels = DeepSpeech.get_labels(model)
+    audio_conf = DeepSpeech.get_audio_conf(model)
+    test_dataset = SpectrogramDataset(audio_conf=audio_conf, manifest_filepath=args.test_manifest, labels=labels,
+                                      normalize=True)
+
+    logits = np.load(args.logits)
+    batch_size = len(logits[0][0])
+    test_loader = AudioDataLoader(test_dataset, batch_size=batch_size, num_workers=args.num_workers)
+
+    results = decode_dataset(logits, test_loader, lm_alpha, lm_beta, labels)
+    print(results)


### PR DESCRIPTION
`transcribe.py` is modified to take a `--word_json` parameter which returns a json-formatted transcription that includes the top path string, as well as all requested paths tokenized with word start/stop times and confidences (currently broken).

`test.py` is modified to optionally be able to skip decoding and simply write the logits to disk.

`tune_decoder.py` reads the written logits in and in parallel sweeps the alpha and beta parameters so that an optimal value may be chosen.