### PR TITLE
Normalizing audio within a 0-1 range

### DIFF
--- a/data/data_loader.py
+++ b/data/data_loader.py
@@ -20,7 +20,7 @@ windows = {'hamming': scipy.signal.hamming, 'hann': scipy.signal.hann, 'blackman
 
 
 def load_audio(path):
-    sound, _ = torchaudio.load(path)
+    sound, _ = torchaudio.load(path, normalization=True)
     sound = sound.numpy()
     if len(sound.shape) > 1:
         if sound.shape[1] == 1:


### PR DESCRIPTION
By default torchaudio loads unnormalized waveform. Maybe it makes sense to normalize within a range of 0-1 as torchaudio has a normalization parameter, which is turned off by default? 