### PR TITLE
Fix misleading file extension in Testing/Inference example

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,13 +240,13 @@ To also note, there is no final softmax layer on the model as when trained, warp
 To evaluate a trained model on a test set (has to be in the same format as the training set):
 
 ```
-python test.py --model-path models/deepspeech.pth.tar --test-manifest /path/to/test_manifest.csv --cuda
+python test.py --model-path models/deepspeech.pth --test-manifest /path/to/test_manifest.csv --cuda
 ```
 
 An example script to output a transcription has been provided:
 
 ```
-python transcribe.py --model-path models/deepspeech.pth.tar --audio-path /path/to/audio.wav
+python transcribe.py --model-path models/deepspeech.pth --audio-path /path/to/audio.wav
 ```
 
 ### Alternate Decoders

--- a/model.py
+++ b/model.py
@@ -286,7 +286,7 @@ if __name__ == '__main__':
     import argparse
 
     parser = argparse.ArgumentParser(description='DeepSpeech model information')
-    parser.add_argument('--model-path', default='models/deepspeech_final.pth.tar',
+    parser.add_argument('--model-path', default='models/deepspeech_final.pth',
                         help='Path to model file created by training')
     args = parser.parse_args()
     package = torch.load(args.model_path, map_location=lambda storage, loc: storage)

--- a/test.py
+++ b/test.py
@@ -10,7 +10,7 @@ from data.data_loader import SpectrogramDataset, AudioDataLoader
 from model import DeepSpeech
 
 parser = argparse.ArgumentParser(description='DeepSpeech transcription')
-parser.add_argument('--model-path', default='models/deepspeech_final.pth.tar',
+parser.add_argument('--model-path', default='models/deepspeech_final.pth',
                     help='Path to model file created by training')
 parser.add_argument('--cuda', action="store_true", help='Use cuda to test model')
 parser.add_argument('--test-manifest', metavar='DIR',

--- a/train.py
+++ b/train.py
@@ -42,7 +42,7 @@ parser.add_argument('--log-dir', default='visualize/deepspeech_final', help='Loc
 parser.add_argument('--log-params', dest='log_params', action='store_true', help='Log parameter values and gradients')
 parser.add_argument('--id', default='Deepspeech training', help='Identifier for visdom/tensorboard run')
 parser.add_argument('--save-folder', default='models/', help='Location to save epoch models')
-parser.add_argument('--model-path', default='models/deepspeech_final.pth.tar',
+parser.add_argument('--model-path', default='models/deepspeech_final.pth',
                     help='Location to save best validation model')
 parser.add_argument('--continue-from', default='', help='Continue from checkpoint model')
 parser.add_argument('--finetune', dest='finetune', action='store_true',

--- a/transcribe.py
+++ b/transcribe.py
@@ -13,7 +13,7 @@ import os.path
 import json
 
 parser = argparse.ArgumentParser(description='DeepSpeech transcription')
-parser.add_argument('--model-path', default='models/deepspeech_final.pth.tar',
+parser.add_argument('--model-path', default='models/deepspeech_final.pth',
                     help='Path to model file created by training')
 parser.add_argument('--audio-path', default='audio.wav',
                     help='Audio file to predict on')

--- a/tune_decoder.py
+++ b/tune_decoder.py
@@ -11,7 +11,7 @@ from decoder import GreedyDecoder, BeamCTCDecoder
 from model import DeepSpeech
 
 parser = argparse.ArgumentParser(description='DeepSpeech transcription')
-parser.add_argument('--model-path', default='models/deepspeech_final.pth.tar',
+parser.add_argument('--model-path', default='models/deepspeech_final.pth',
                     help='Path to model file created by training')
 parser.add_argument('--logits', default="", type=str, help='Path to logits from test.py')
 parser.add_argument('--test-manifest', metavar='DIR',


### PR DESCRIPTION
Changing misleading file extensions in the testing and inference examples. These examples do not need `.tar` examples to work. 