### PR TITLE
Fix tune decoder

### DIFF
--- a/tune_decoder.py
+++ b/tune_decoder.py
@@ -60,7 +60,7 @@ def decode_dataset(logits, test_dataset, batch_size, lm_alpha, lm_beta, mesh_x, 
         out = torch.from_numpy(logits[i][0])
         sizes = torch.from_numpy(logits[i][1])
 
-        decoded_output, _, _, _ = decoder.decode(out, sizes)
+        decoded_output, _, = decoder.decode(out, sizes)
         target_strings = target_decoder.convert_to_strings(split_targets)
         wer, cer = 0, 0
         for x in range(len(target_strings)):

--- a/tune_decoder.py
+++ b/tune_decoder.py
@@ -92,7 +92,7 @@ if __name__ == '__main__':
                                       normalize=True)
 
     logits = np.load(args.logits)
-    batch_size = logits[0][0].shape[1]
+    batch_size = logits[0][0].shape[0]
 
     results = []
 


### PR DESCRIPTION
1.  The outputs from decoder.decode are not correctly assigned. Some must have confused `BeamCTCDecoder.decode` with `CTCBeamDecoder.decode`

2. [This](https://github.com/SeanNaren/deepspeech.pytorch/commit/e1aef159148c5aa601a3811a2ab3fa5efe94ce5b) commit removed unnecessary transposes, because of which `batch_size` calculation messed up. 