### PR TITLE
Update to PyTorch v0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,51 @@
-FROM floydhub/pytorch:0.3.0-gpu.cuda9cudnn7-py3.24
-
-# install basics 
-RUN apt-get update -y
-RUN apt-get install -y git cmake tree htop bmon iotop
-
-# install python deps
-RUN pip install cffi tensorboardX
+FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
 
 WORKDIR /workspace/
 
+# install basics 
+RUN apt-get update -y
+RUN apt-get install -y git curl ca-certificates bzip2 cmake tree htop bmon iotop
+
+# Install Miniconda
+RUN curl -so /miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-4.4.10-Linux-x86_64.sh \
+ && chmod +x /miniconda.sh \
+ && /miniconda.sh -b -p /miniconda \
+ && rm /miniconda.sh
+
+ENV PATH=/miniconda/bin:$PATH
+
+# Create a Python 3.6 environment
+RUN /miniconda/bin/conda install conda-build \
+ && /miniconda/bin/conda create -y --name py36 python=3.6.4 \
+ && /miniconda/bin/conda clean -ya
+
+ENV CONDA_DEFAULT_ENV=py36
+ENV CONDA_PREFIX=/miniconda/envs/$CONDA_DEFAULT_ENV
+ENV PATH=$CONDA_PREFIX/bin:$PATH
+
+# Ensure conda version is at least 4.4.11
+# (because of this issue: https://github.com/conda/conda/issues/6811)
+ENV CONDA_AUTO_UPDATE_CONDA=false
+RUN conda install -y "conda>=4.4.11" && conda clean -ya
+
+RUN conda install pytorch torchvision cuda90 -c pytorch && conda clean -ya
+
+# Install HDF5 Python bindings
+RUN conda install -y \
+    h5py \
+ && conda clean -ya
+RUN pip install h5py-cache
+
+# install python deps
+RUN pip install cython cffi tensorboardX
+
 # install warp-CTC
+
+ENV CUDA_HOME=/usr/local/cuda
+RUN apt-get install -y g++
 RUN git clone https://github.com/SeanNaren/warp-ctc.git
 RUN cd warp-ctc; mkdir build; cd build; cmake ..; make
-RUN cd warp-ctc; cd pytorch_binding; CUDA_HOME="/usr/local/cuda" python setup.py install
+RUN cd warp-ctc; cd pytorch_binding; python setup.py install
 
 # install pytorch audio
 RUN apt-get install -y sox libsox-dev libsox-fmt-all
@@ -23,11 +56,8 @@ RUN cd audio; python setup.py install
 RUN git clone --recursive https://github.com/parlance/ctcdecode.git
 RUN cd ctcdecode; pip install .
 
-# install deepspeech2 pytorch implementation 
-RUN git clone https://github.com/SeanNaren/deepspeech.pytorch
+# install deepspeech2 pytorch implementation
+ADD . /workspace/deepspeech.pytorch
 RUN cd deepspeech.pytorch; pip install -r requirements.txt
 
-# launch jupiter
-RUN pip install jupyter 
-RUN mkdir data; mkdir notebooks;
-CMD jupyter-notebook --ip="*" --no-browser --allow-root
+WORKDIR /workspace/deepspeech.pytorch

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,4 +60,13 @@ RUN cd ctcdecode; pip install .
 ADD . /workspace/deepspeech.pytorch
 RUN cd deepspeech.pytorch; pip install -r requirements.txt
 
+# Set-up Docker to PyCharm remote debugging
+RUN apt-get install -y openssh-server
+RUN mkdir /var/run/sshd
+RUN echo 'root:testssh' | chpasswd
+RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+RUN echo "export VISIBLE=now" >> /etc/profile
+RUN service ssh restart
+
 WORKDIR /workspace/deepspeech.pytorch

--- a/data/librispeech.py
+++ b/data/librispeech.py
@@ -4,6 +4,7 @@ import tarfile
 import argparse
 import subprocess
 from utils import create_manifest
+from tqdm import tqdm
 import shutil
 
 parser = argparse.ArgumentParser(description='Processes and downloads LibriSpeech dataset.')
@@ -94,7 +95,7 @@ def main():
             os.remove(target_filename)
             print("Converting flac files to wav and extracting transcripts...")
             assert os.path.exists(extracted_dir), "Archive {} was not properly uncompressed.".format(filename)
-            for root, subdirs, files in os.walk(extracted_dir):
+            for root, subdirs, files in tqdm(os.walk(extracted_dir)):
                 for f in files:
                     if f.find(".flac") != -1:
                         _process_file(wav_dir=split_wav_dir, txt_dir=split_txt_dir,

--- a/decoder.py
+++ b/decoder.py
@@ -121,7 +121,7 @@ class BeamCTCDecoder(Decoder):
                 if sizes[b][p] > 0:
                     utterances.append(utt[0:size])
                 else:
-                    utterances.append(torch.IntTensor())
+                    utterances.append(torch.tensor([], dtype=torch.int))
             results.append(utterances)
         return results
 
@@ -166,10 +166,10 @@ class GreedyDecoder(Decoder):
         string = ''
         offsets = []
         for i in range(size):
-            char = self.int_to_char[sequence[i]]
+            char = self.int_to_char[sequence[i].item()]
             if char != self.int_to_char[self.blank_index]:
                 # if this char is a repetition and remove_repetitions=true, then skip
-                if remove_repetitions and i != 0 and char == self.int_to_char[sequence[i - 1]]:
+                if remove_repetitions and i != 0 and char == self.int_to_char[sequence[i - 1].item()]:
                     pass
                 elif char == self.labels[self.space_index]:
                     string += ' '
@@ -177,7 +177,7 @@ class GreedyDecoder(Decoder):
                 else:
                     string = string + char
                     offsets.append(i)
-        return string, torch.IntTensor(offsets)
+        return string, torch.tensor(offsets, dtype=torch.int)
 
     def decode(self, probs, sizes=None):
         """

--- a/decoder.py
+++ b/decoder.py
@@ -105,7 +105,7 @@ class BeamCTCDecoder(Decoder):
             for p, utt in enumerate(batch):
                 size = seq_len[b][p]
                 if size > 0:
-                    transcript = ''.join(map(lambda x: self.int_to_char[x], utt[0:size]))
+                    transcript = ''.join(map(lambda x: self.int_to_char[x.item()], utt[0:size]))
                 else:
                     transcript = ''
                 utterances.append(transcript)

--- a/noise_inject.py
+++ b/noise_inject.py
@@ -17,6 +17,6 @@ args = parser.parse_args()
 noise_injector = NoiseInjection()
 data = load_audio(args.input_path)
 mixed_data = noise_injector.inject_noise_sample(data, args.noise_path, args.noise_level)
-mixed_data = torch.FloatTensor(mixed_data).unsqueeze(1)  # Add channels dim
+mixed_data = torch.tensor(mixed_data, dtype=torch.float).unsqueeze(1)  # Add channels dim
 torchaudio.save(args.output_path, mixed_data, args.sample_rate)
 print('Saved mixed file to %s' % args.output_path)


### PR DESCRIPTION
## Summary
This adds support for the newest update of pytorch, version 0.4. The changes are, however, not backwards compatible. Nevertheless this is a much needed update due to the third party dependencies such as torchaudio that have been updated to support pytorch 0.4 only.

## Changes
- The `Variable` wrapper was eliminated when used in an inference scenario, but it was kept unchanged for training, as it doesn't have any effect.
 - code for inference that used the `volatile` flag in now within a `with torch.no_grad()`
 - decoders `convert_to_string` method was failing due the new way of accessing tensor values with `x.item()`
 - some tensor creation ops where replaced with the new syntax `torch.tensor`

## Issues
 - Couldn't make `transcribe.py` work with the `--decoder beam --lm-path /path/to/lm`  flags, probably due to a CTCDecoder issue with the new tensor formats of pytorch 0.4 (see #293 )