### PR TITLE
Fix "RuntimeError: Expected object of type torch.FloatTensor but foun…

### DIFF
--- a/train.py
+++ b/train.py
@@ -139,6 +139,8 @@ if __name__ == '__main__':
         optimizer = torch.optim.SGD(parameters, lr=args.lr,
                                     momentum=args.momentum, nesterov=True)
         if not args.finetune:  # Don't want to restart training
+            if args.cuda:
+                model.cuda()
             optimizer.load_state_dict(package['optim_dict'])
             start_epoch = int(package.get('epoch', 1)) - 1  # Index start at 0 for training
             start_iter = package.get('iteration', None)


### PR DESCRIPTION
Fix following runtime error when continued training using gpu, the model has to be cuda before optimizer load state dict, the tensor inside will still be cpu float type otherwise.

```error
Traceback (most recent call last):
  File "train.py", line 270, in <module>
    optimizer.step()
  File "/usr/local/lib/python3.6/dist-packages/torch/optim/sgd.py", line 101, in step
    buf.mul_(momentum).add_(1 - dampening, d_p)
RuntimeError: Expected object of type torch.FloatTensor but found type torch.cuda.FloatTensor for argument #4 'other'
```