### PR TITLE
Installing stable PyAudio 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Install pytorch audio:
 ```
 sudo apt-get install sox libsox-dev libsox-fmt-all
 git clone https://github.com/pytorch/audio.git
+git checkout d92de5b97fc6204db4b1e3ed20c03ac06f5d53f0
 cd audio && python setup.py install
 ```
 


### PR DESCRIPTION
Using the master of PyAudio is unstable and changes are made, to keep the support for `Pytorch 1.1.0` and `CUDA 10.0` you need to checkout to the latest stable commit.