### PR TITLE
fix logger bug

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -18,9 +18,9 @@ class VisdomLogger(object):
 
     def update(self, epoch, values):
         x_axis = self.epochs[0:epoch + 1]
-        y_axis = torch.stack((values["loss_results"][:epoch + 1],
-                              values["wer_results"][:epoch + 1],
-                              values["cer_results"][:epoch + 1]),
+        y_axis = torch.stack((values["loss_results"][:epoch],
+                              values["wer_results"][:epoch],
+                              values["cer_results"][:epoch]),
                              dim=1)
         self.viz_window = self.viz.line(
             X=x_axis,
@@ -43,8 +43,8 @@ class TensorBoardLogger(object):
         self.log_params = log_params
 
     def update(self, epoch, values, parameters=None):
-        loss, wer, cer = values["loss_results"][epoch + 1], values["wer_results"][epoch + 1], \
-                         values["cer_results"][epoch + 1]
+        loss, wer, cer = values["loss_results"][epoch], values["wer_results"][epoch], \
+                         values["cer_results"][epoch]
         values = {
             'Avg Train Loss': loss,
             'Avg WER': wer,


### PR DESCRIPTION
Hi

In `train.py` at line 310-312, we write evaluation results at `epoch`'th index of `loss_results`, `wer_results` and `cer_results` tensors. While in `logger.py` we read violate variables from one ahead index (lines 21-23 in visdom logger and lines 46-47 in tensorboards logger). This cause to see nonsense log like this:
![Screenshot_2020-04-03 TensorBoard](https://user-images.githubusercontent.com/8940780/78362838-0671f380-75d0-11ea-8ffd-618452906233.png)
