### PR TITLE
save output for lm search

### DIFF
--- a/search_lm_params.py
+++ b/search_lm_params.py
@@ -34,7 +34,7 @@ if args.lm_path is None:
 
 model = DeepSpeech.load_model(args.model_path)
 
-saved_output = np.load(args.saved_output)
+saved_output = torch.load(args.saved_output)
 
 
 def init(beam_width, blank_index, lm_path):
@@ -50,8 +50,6 @@ def decode_dataset(params):
 
     total_cer, total_wer, num_tokens, num_chars = 0, 0, 0, 0
     for out, sizes, target_strings in saved_output:
-        out = torch.Tensor(out).float()
-        sizes = torch.Tensor(sizes).int()
         decoded_output, _, = decoder.decode(out, sizes)
         for x in range(len(target_strings)):
             transcript, reference = decoded_output[x][0], target_strings[x][0]

--- a/test.py
+++ b/test.py
@@ -44,7 +44,7 @@ def evaluate(test_loader, device, model, decoder, target_decoder, save_output=Fa
 
         if save_output is not None:
             # add output to data array, and continue
-            output_data.append((out.cpu().numpy(), output_sizes.numpy(), target_strings))
+            output_data.append((out.cpu(), output_sizes, target_strings))
         for x in range(len(target_strings)):
             transcript, reference = decoded_output[x][0], target_strings[x][0]
             wer_inst = decoder.wer(transcript, reference)
@@ -97,4 +97,4 @@ if __name__ == '__main__':
           'Average WER {wer:.3f}\t'
           'Average CER {cer:.3f}\t'.format(wer=wer, cer=cer))
     if args.save_output is not None:
-        np.save(args.save_output, output_data)
+        torch.save(output_data, args.save_output)


### PR DESCRIPTION
Hi

I tried to dump acoustic model output to search for optimum beam search parameters:
`python3.8 test.py --test-manifest /media/aj/vf/voxforge.csv --model-path models/deepspeech_final.pth --cuda --half --save-output voxforge.npy`

And I get the following error:

> 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:05<00:00,  1.16it/s]
Test Summary 	Average WER 51.965	Average CER 15.761	
Traceback (most recent call last):
  File "test.py", line 101, in <module>
    np.save(args.save_output, output_data)
  File "<__array_function__ internals>", line 5, in save
  File "/usr/local/lib/python3.8/dist-packages/numpy/lib/npyio.py", line 551, in save
    arr = np.asanyarray(arr)
  File "/usr/local/lib/python3.8/dist-packages/numpy/core/_asarray.py", line 138, in asanyarray
    return array(a, dtype, copy=False, order=order, subok=True)
ValueError: could not broadcast input array from shape (20,476,37) into shape (20)

It seems that numpy can not save `output_data`.

I replace dumping method to use `pytorch.save` instead of `np.save` and it works just fine. It also eliminate some data conversion (from pth to np and vice versa).

regards