### PR TITLE
Fix two small bugs

### DIFF
--- a/multiproc.py
+++ b/multiproc.py
@@ -1,6 +1,7 @@
-import torch
-import sys
 import subprocess
+import sys
+
+import torch
 
 argslist = list(sys.argv)[1:]
 world_size = torch.cuda.device_count()
@@ -19,21 +20,20 @@ else:
     argslist.append(str(world_size))
 
 workers = []
+if '--rank' not in argslist:
+    argslist.append('--rank')
+    argslist.append(str(0))
+
+if '--gpu-rank' not in argslist:
+    argslist.append('--gpu-rank')
+    argslist.append(str(0))
 
 for i in range(world_size):
-    if '--rank' in argslist:
-        argslist[argslist.index('--rank') + 1] = str(i)
+    argslist[argslist.index('--rank') + 1] = str(i)
+    if device_ids:
+        argslist[argslist.index('--gpu-rank') + 1] = str(device_ids[i])
     else:
-        argslist.append('--rank')
-        argslist.append(str(i))
-    if '--gpu-rank' in argslist:
-        if device_ids:
-            argslist[argslist.index('--gpu-rank') + 1] = str(device_ids[i])
-        else:
-            argslist[argslist.index('--gpu-rank') + 1] = str(i)
-    else:
-        argslist.append('--gpu-rank')
-        argslist.append(str(i))
+        argslist[argslist.index('--gpu-rank') + 1] = str(i)
     stdout = None if i == 0 else open("GPU_" + str(i) + ".log", "w")
     print(argslist)
     p = subprocess.Popen([str(sys.executable)] + argslist, stdout=stdout, stderr=stdout)

--- a/test.py
+++ b/test.py
@@ -1,10 +1,10 @@
 import argparse
 
 import numpy as np
-import torch
 from tqdm import tqdm
 
-from data.data_loader import SpectrogramDataset, AudioDataLoader
+import torch
+from data.data_loader import AudioDataLoader, SpectrogramDataset
 from decoder import GreedyDecoder
 from opts import add_decoder_args, add_inference_args
 from utils import load_model
@@ -20,7 +20,7 @@ parser.add_argument('--save-output', default=None, help="Saves output of model f
 parser = add_decoder_args(parser)
 
 
-def evaluate(test_loader, device, model, decoder, target_decoder, save_output=False, verbose=False, half=False):
+def evaluate(test_loader, device, model, decoder, target_decoder, save_output=None, verbose=False, half=False):
     model.eval()
     total_cer, total_wer, num_tokens, num_chars = 0, 0, 0, 0
     output_data = []


### PR DESCRIPTION
the first bug is in  `test.py`

the default value of the parameter `save_output` of the function `evaluate` is preferably `None`
because  the value of the conditional statements`save_output is not None`  is always `true` when `save_output= False`

----

the second bug is in `multiproc.py`
EASE:

```
python -m multiproc train.py --train-manifest data/train_manifest.csv --val-manifest data/val_manifest.csv --cuda --device-ids 1,2,3,
5
['train.py', '--train-manifest', 'data/train_manifest.csv', '--val-manifest', 'data/val_manifest.csv', '--cuda', '--world-size',
'4', '--rank', '0', '--gpu-rank', '0']
['train.py', '--train-manifest', 'data/train_manifest.csv', '--val-manifest', 'data/val_manifest.csv', '--cuda',  '--world-size',
'4', '--rank', '1', '--gpu-rank', '2']
['train.py', '--train-manifest', 'data/train_manifest.csv', '--val-manifest', 'data/val_manifest.csv',  '--cuda', '--world-size',
'4', '--rank', '2', '--gpu-rank', '3']
['train.py', '--train-manifest', 'data/train_manifest.csv', '--val-manifest', 'data/val_manifest.csv', '--cuda',  '--world-size',
'4', '--rank', '3', '--gpu-rank', '5']
```
Obviously there is a problem with the gpu-rank parameter of the first command, it should be  '1'
I fixed this problem and cleaned the code by the way