### PR TITLE
Fix warnings of alpha = torch.tensor(queries - floor, dtype=grid_type)

### DIFF
--- a/data/sparse_image_warp.py
+++ b/data/sparse_image_warp.py
@@ -372,7 +372,7 @@ def interpolate_bilinear(grid,
 
         # alpha has the same type as the grid, as we will directly use alpha
         # when taking linear combinations of pixel values from the image.
-        alpha = torch.tensor(queries - floor, dtype=grid_type)
+        alpha = queries.clone().detach() - floor.clone().detach()
         min_alpha = torch.tensor(0.0, dtype=grid_type)
         max_alpha = torch.tensor(1.0, dtype=grid_type)
         alpha = torch.min(torch.max(min_alpha, alpha), max_alpha)


### PR DESCRIPTION
Fixed the warning probably below.
```
alpha = torch.tensor(queries - floor, dtype=grid_type)
./data/sparse_image_warp.py:375: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
```

