### PR TITLE
Added Jupyter as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ soundfile
 pytest
 hydra-core==1.0.0rc1
 google-cloud-storage
+jupyter


### PR DESCRIPTION
After pulling the docker container,  solving the  `jupyter-notebook: command not` error