### PR TITLE
avoid perf measure rounding

### DIFF
--- a/deepspeech_pytorch/state.py
+++ b/deepspeech_pytorch/state.py
@@ -60,9 +60,9 @@ class TrainingState:
         self.amp_state = amp.state_dict()
 
     def init_results_tracking(self, epochs):
-        self.result_state = ResultState(loss_results=torch.IntTensor(epochs),
-                                        wer_results=torch.IntTensor(epochs),
-                                        cer_results=torch.IntTensor(epochs))
+        self.result_state = ResultState(loss_results=torch.FloatTensor(epochs),
+                                        wer_results=torch.FloatTensor(epochs),
+                                        cer_results=torch.FloatTensor(epochs))
 
     def add_results(self,
                     epoch,


### PR DESCRIPTION
Hi

Loss values, CER and WER measures are stored in a `torch.IntTensor` instance, causing the error in visualization:

![image](https://user-images.githubusercontent.com/8940780/94994996-13d06080-05a8-11eb-9435-8eb1679db1e1.png)

For e.g., the image above must depict a smooth reduction in CER measure (10.815, 10.434, 10.393, 10.384, 10.195, 9.974), but due to rounding the values to integers, it's plotted in a wrong fashion.

Regards