### PR TITLE
bug fix for integer division

### DIFF
--- a/deepspeech_pytorch/model.py
+++ b/deepspeech_pytorch/model.py
@@ -216,7 +216,7 @@ class DeepSpeech(nn.Module):
         seq_len = input_length
         for m in self.conv.modules():
             if type(m) == nn.modules.conv.Conv2d:
-                seq_len = ((seq_len + 2 * m.padding[1] - m.dilation[1] * (m.kernel_size[1] - 1) - 1) / m.stride[1] + 1)
+                seq_len = ((seq_len + 2 * m.padding[1] - m.dilation[1] * (m.kernel_size[1] - 1) - 1) // m.stride[1] + 1)
         return seq_len.int()
 
     @classmethod


### PR DESCRIPTION
Hi

There is an error at `get_seq_len` method due to dividing `torch.LongTensor` by `/` operator:
`RuntimeError: Integer division of tensors using div or / is no longer supported, and in a future release div will perform true division as in Python 3. Use true_divide or floor_divide (// in Python) instead.`

Here is a fix for it.
