### PR TITLE
use tmpfs mount for /tmp in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Implementation of DeepSpeech2 for PyTorch. The repo supports training/testing an
 To use the image with a GPU you'll need to have [nvidia-docker](https://github.com/NVIDIA/nvidia-docker) installed.
 
 ```bash
-sudo docker run -ti --gpus all -v `pwd`/data:/workspace/data -p 8888:8888 --net=host --ipc=host seannaren/deepspeech.pytorch:latest # Opens a Jupyter notebook, mounting the /data drive in the container
+sudo docker run -ti --gpus all -v `pwd`/data:/workspace/data --tmpfs /tmp -p 8888:8888 --net=host --ipc=host seannaren/deepspeech.pytorch:latest # Opens a Jupyter notebook, mounting the /data drive in the container
 ```
 
 Optionally you can use the command line by changing the entrypoint:
 
 ```bash
-sudo docker run -ti --gpus all -v `pwd`/data:/workspace/data --entrypoint=/bin/bash --net=host --ipc=host seannaren/deepspeech.pytorch:latest
+sudo docker run -ti --gpus all -v `pwd`/data:/workspace/data --tmpfs /tmp --entrypoint=/bin/bash --net=host --ipc=host seannaren/deepspeech.pytorch:latest
 ```
 
 ### From Source


### PR DESCRIPTION
Hi,

In Multi-GPU Training using Docker, audio augmentation is done with `sox` and the output is written in `/tmp` by [NamedTemporaryFile](https://github.com/SeanNaren/deepspeech.pytorch/blob/a5e05de65275f5ea14123bb215e36ca3f5179a80/deepspeech_pytorch/loader/data_loader.py#L326). This mechanism utilizes the disk storage with a write and a read on container’s writable layer for each audio augmentation, if `/tmp` is not mounted with tmpfs:

![wo-tmpfs-docker](https://user-images.githubusercontent.com/1765587/99202537-bb09ff80-27c4-11eb-8ab3-28940b951023.jpg)

While using Docker, it can be done by adding `--tmpfs /tmp` when creating a container:
```
$ docker run \
      --interactive \
      --tty \
      --detach \
      --name deepspeech-pytorch \
      --gpus all \
      --ipc=host \
      --volume `pwd`/data:/workspace/data \
      --entrypoint=/bin/bash \
      --tmpfs /tmp \
      seannaren/deepspeech.pytorch:latest
```

The created container has tmpfs mount for /tmp:
```
$ mount | grep /tmp
tmpfs on /tmp type tmpfs (rw,nosuid,nodev,noexec,relatime)
```
Audio augmentations will be done in memory instead of disk storage:

![tmpfs-docker](https://user-images.githubusercontent.com/1765587/99202648-0c19f380-27c5-11eb-89de-fe7dcaf36663.jpg)
