### PR TITLE
Specify blank index explicitly

### DIFF
--- a/deepspeech_pytorch/utils.py
+++ b/deepspeech_pytorch/utils.py
@@ -46,7 +46,8 @@ def load_decoder(labels, cfg: LMConfig):
                                  cutoff_top_n=cfg.cutoff_top_n,
                                  cutoff_prob=cfg.cutoff_prob,
                                  beam_width=cfg.beam_width,
-                                 num_processes=cfg.lm_workers)
+                                 num_processes=cfg.lm_workers,
+                                 blank_index=labels.index('_'))
     else:
         decoder = GreedyDecoder(labels=labels,
                                 blank_index=labels.index('_'))


### PR DESCRIPTION
The `BeamCTCDecoder` assumes that the `blank_index` is always at position 0.
Specify it explicitly to avoid potential issues with labels.

Resolves #595