### PR TITLE
Fix Syntax Warning

### DIFF
--- a/deepspeech_pytorch/inference.py
+++ b/deepspeech_pytorch/inference.py
@@ -85,7 +85,7 @@ def run_transcribe(audio_path: str,
     spect = spect.view(1, 1, spect.size(0), spect.size(1))
     spect = spect.to(device)
     input_sizes = torch.IntTensor([spect.size(3)]).int()
-    with autocast(enabled=precision is 16):
+    with autocast(enabled=precision == 16):
         out, output_sizes = model(spect, input_sizes)
     decoded_output, decoded_offsets = decoder.decode(out, output_sizes)
     return decoded_output, decoded_offsets

--- a/deepspeech_pytorch/model.py
+++ b/deepspeech_pytorch/model.py
@@ -246,7 +246,7 @@ class DeepSpeech(pl.LightningModule):
         inputs, targets, input_percentages, target_sizes = batch
         input_sizes = input_percentages.mul_(int(inputs.size(3))).int()
         inputs = inputs.to(self.device)
-        with autocast(enabled=self.precision is 16):
+        with autocast(enabled=self.precision == 16):
             out, output_sizes = self(inputs, input_sizes)
         decoded_output, _ = self.evaluation_decoder.decode(out, output_sizes)
         self.wer(

--- a/deepspeech_pytorch/validation.py
+++ b/deepspeech_pytorch/validation.py
@@ -152,7 +152,7 @@ def run_evaluation(test_loader,
         inputs, targets, input_percentages, target_sizes = batch
         input_sizes = input_percentages.mul_(int(inputs.size(3))).int()
         inputs = inputs.to(device)
-        with autocast(enabled=precision is 16):
+        with autocast(enabled=precision == 16):
             out, output_sizes = model(inputs, input_sizes)
         decoded_output, _ = decoder.decode(out, output_sizes)
         wer.update(


### PR DESCRIPTION
Resolve the warning

```
SyntaxWarning: "is" with a literal. Did you mean "=="?
  with autocast(enabled=self.precision is 16):
```