### PR TITLE
Use torchaudio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 scipy
 numpy
-soundfile
 python-levenshtein
 torch
 torchelastic
@@ -12,7 +11,6 @@ matplotlib
 flask
 sox
 sklearn
-soundfile
 pytest
 hydra-core
 google-cloud-storage

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ scipy
 numpy
 python-levenshtein
 torch
+torchaudio
 torchelastic
 pytorch-lightning>=1.1
 wget


### PR DESCRIPTION
Use torchaudio instead of soundfile.

This allows us to use non-wave files like MP3.

`load()` already normalizes the data by default and returns a [channel x length] array.
Plus it has support for different codecs unsupported by `libsndfile`.