### PR TITLE
Check for gpu config for is_distributed

### DIFF
--- a/deepspeech_pytorch/training.py
+++ b/deepspeech_pytorch/training.py
@@ -35,7 +35,7 @@ def train(cfg: DeepSpeechConfig):
         labels=labels,
         data_cfg=cfg.data,
         normalize=True,
-        is_distributed=cfg.trainer.gpus > 1
+        is_distributed=cfg.trainer.gpus is not None and cfg.trainer.gpus > 1
     )
 
     model = DeepSpeech(


### PR DESCRIPTION
If training on CPU, you generally won't pass a GPU key in your config.

If you don't pass a GPU key, the following line will fail with a key error.
This way, we check if the `gpu` key is available first.