### PR TITLE
Fix GCS config

### DIFF
--- a/deepspeech_pytorch/configs/train_config.py
+++ b/deepspeech_pytorch/configs/train_config.py
@@ -90,7 +90,7 @@ class DeepSpeechConfig:
     defaults: List[Any] = field(default_factory=lambda: defaults)
     optim: Any = MISSING
     model: Any = MISSING
-    checkpoint: Any = MISSING
+    checkpoint: ModelCheckpointConf = MISSING
     trainer: DeepSpeechTrainerConf = DeepSpeechTrainerConf()
     data: DataConfig = DataConfig()
     augmentation: AugmentationConfig = AugmentationConfig()

--- a/deepspeech_pytorch/training.py
+++ b/deepspeech_pytorch/training.py
@@ -21,7 +21,6 @@ def train(cfg: DeepSpeechConfig):
             checkpoint_callback = GCSCheckpointHandler(
                 cfg=cfg.checkpoint
             )
-            cfg.trainer.callbacks = [checkpoint_callback]
         else:
             checkpoint_callback = FileCheckpointHandler(
                 cfg=cfg.checkpoint


### PR DESCRIPTION
if `trainer.callbacks` is not `[]` or specified in the yaml config, `training.py` will fail.
I don't see `trainer.callbacks` used anywhere and it seems it's already set manually later on so I removed it.

Also to support Hydra's nested instantation, I modified the checkpoint config field to be a base  `ModelCheckpointConf`