### PR TITLE
Fix gcs config path

### DIFF
--- a/deepspeech_pytorch/configs/train_config.py
+++ b/deepspeech_pytorch/configs/train_config.py
@@ -77,7 +77,6 @@ class AdamConfig(OptimConfig):
 class GCSCheckpointConfig(ModelCheckpointConf):
     gcs_bucket: str = MISSING  # Bucket to store model checkpoints e.g bucket-name
     gcs_save_folder: str = MISSING  # Folder to store model checkpoints in bucket e.g models/
-    local_save_file: str = './local_checkpoint.pth'  # Place to store temp file on disk
 
 
 @dataclass


### PR DESCRIPTION
I discovered another bug with the GCS config.
It looks like the `local_save_file` isn't really necessary since PTL trainer already saves the model locally.
Also, `GCSCheckpointHandler` complains (after completing an epoch, which is not ideal) that it can't find a saved file if it's not specified correctly.

We can instead upload the file that the trainer is already using and avoid having the user to manually specify a save file.

The `GCSCheckpointHandler` now also properly saves to the user's desired folder instead of the full path to the model
So previously it would be saved as some thing like `<bucket_name>/home/user/path/to/model.ckpt`
Now it actually saves it to the bucket/folder correctly.
