### PR TITLE
remove uneffective data view changer

### DIFF
--- a/deepspeech_pytorch/model.py
+++ b/deepspeech_pytorch/model.py
@@ -98,7 +98,7 @@ class BatchRNN(nn.Module):
         x, h = self.rnn(x)
         x, _ = nn.utils.rnn.pad_packed_sequence(x)
         if self.bidirectional:
-            x = x.view(x.size(0), x.size(1), 2, -1).sum(2).view(x.size(0), x.size(1), -1)  # (TxNxH*2) -> (TxNxH) by sum
+            x = x.view(x.size(0), x.size(1), 2, -1).sum(2)  # (TxNxH*2) -> (TxNxH) by sum
         return x
 
 


### PR DESCRIPTION
Hi

Getting the sum with dim=2, yield a torch array of the shape (TxNxH) and there is no need to change the output view.

Regards