### PR TITLE
Update: PL latest release

### DIFF
--- a/deepspeech_pytorch/configs/lightning_config.py
+++ b/deepspeech_pytorch/configs/lightning_config.py
@@ -10,11 +10,6 @@ import pytorch_lightning
 from pytorch_lightning.callbacks.stochastic_weight_avg import StochasticWeightAveraging
 
 
-_PL_GREATER_THAN_EQUAL_1_7_0 = Version(pytorch_lightning.__version__) >= Version(
-    "0.7.0"
-)
-
-
 @dataclass
 class ModelCheckpointConf:
     _target_: str = "pytorch_lightning.callbacks.ModelCheckpoint"
@@ -43,24 +38,14 @@ class TrainerConf:
     enable_checkpointing: bool = True
     default_root_dir: Optional[str] = None
     gradient_clip_val: float = 0
-    if _PL_GREATER_THAN_EQUAL_1_7_0:
-        callbacks: Any = field(
-            default_factory=lambda: [
-                TQDMProgressBar(process_position=0, refresh_rate=1),
-                DeviceStatsMonitor(),
-                ModelSummary(),
-                StochasticWeightAveraging(swa_lrs=1e-2),
-            ]
-        )
-    else:
-        callbacks: Any = None  # Optional[List[Callback]]
-        process_position: int = 0
-        progress_bar_refresh_rate: int = 1
-        log_gpu_memory: Optional[str] = None
-        flush_logs_every_n_steps: int = 100
-        weights_summary: Optional[str] = "top"
-        prepare_data_per_node: bool = True
-        stochastic_weight_avg: bool = False
+    callbacks: Any = field(
+        default_factory=lambda: [
+            TQDMProgressBar(process_position=0, refresh_rate=1),
+            DeviceStatsMonitor(),
+            ModelSummary(),
+            StochasticWeightAveraging(swa_lrs=1e-2),
+        ]
+    )
     num_nodes: int = 1
     num_processes: int = 1
     gpus: Any = None  # Union[int, str, List[int], NoneType]

--- a/deepspeech_pytorch/configs/lightning_config.py
+++ b/deepspeech_pytorch/configs/lightning_config.py
@@ -1,6 +1,13 @@
 from dataclasses import dataclass
 from typing import Any
 from typing import Optional
+from packaging.version import Version
+
+from pytorch_lightning.callbacks.progress.tqdm_progress import TQDMProgressBar
+import pytorch_lightning
+
+
+_PL_GREATER_THAN_EQUAL_1_7_0 = Version(pytorch_lightning.__version__) >= Version("0.7.0")
 
 
 @dataclass
@@ -27,10 +34,13 @@ class TrainerConf:
     _target_: str = "pytorch_lightning.trainer.Trainer"
     logger: Any = True  # Union[LightningLoggerBase, Iterable[LightningLoggerBase], bool]
     enable_checkpointing: bool = True
-    callbacks: Any = None  # Optional[List[Callback]]
     default_root_dir: Optional[str] = None
     gradient_clip_val: float = 0
-    process_position: int = 0
+    if _PL_GREATER_THAN_EQUAL_1_7_0:
+        callbacks: Any = [TQDMProgressBar(process_position=0)]
+    else:
+        callbacks: Any = None  # Optional[List[Callback]]
+        process_position: int = 0
     num_nodes: int = 1
     num_processes: int = 1
     gpus: Any = None  # Union[int, str, List[int], NoneType]

--- a/deepspeech_pytorch/configs/lightning_config.py
+++ b/deepspeech_pytorch/configs/lightning_config.py
@@ -1,13 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Any
 from typing import Optional
-from packaging.version import Version
-from pytorch_lightning.callbacks.device_stats_monitor import DeviceStatsMonitor
-from pytorch_lightning.callbacks.model_summary import ModelSummary
-
-from pytorch_lightning.callbacks.progress.tqdm_progress import TQDMProgressBar
-import pytorch_lightning
-from pytorch_lightning.callbacks.stochastic_weight_avg import StochasticWeightAveraging
 
 
 @dataclass
@@ -31,21 +24,14 @@ class ModelCheckpointConf:
 
 @dataclass
 class TrainerConf:
-    _target_: str = "pytorch_lightning.Trainer"
+    _target_: str = "pytorch_lightning.trainer.Trainer"
     logger: Any = (
         True  # Union[LightningLoggerBase, Iterable[LightningLoggerBase], bool]
     )
     enable_checkpointing: bool = True
     default_root_dir: Optional[str] = None
     gradient_clip_val: float = 0
-    callbacks: Any = field(
-        default_factory=lambda: [
-            TQDMProgressBar(process_position=0, refresh_rate=1),
-            DeviceStatsMonitor(),
-            ModelSummary(),
-            StochasticWeightAveraging(swa_lrs=1e-2),
-        ]
-    )
+    callbacks: Any = None
     num_nodes: int = 1
     num_processes: int = 1
     gpus: Any = None  # Union[int, str, List[int], NoneType]

--- a/deepspeech_pytorch/configs/train_config.py
+++ b/deepspeech_pytorch/configs/train_config.py
@@ -40,6 +40,7 @@ class DataConfig:
     labels_path: str = 'labels.json'  # Contains tokens for model output
     spect: SpectConfig = SpectConfig()
     augmentation: AugmentationConfig = AugmentationConfig()
+    prepare_data_per_node: bool = True
 
 
 @dataclass

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ numpy
 optuna
 pytest
 python-levenshtein
-pytorch-lightning>=1.1
+pytorch-lightning>=1.7.0
 scipy
 sklearn
 sox


### PR DESCRIPTION
Hi, @SeanNaren - Hope you're doing well. Lightning Ecosystem CI was failing with the following errors for a few attributes:

```bash
TypeError: __init__() got an unexpected keyword argument 'process_position'
```

These are some attributes that were removed in PL 1.7.0 release, post deprecation. This PR adds an alternative of each one of them, most of them as callbacks. `prepare_data_per_node` was shifted to `LightningDataModule/LightningModule` from `Trainer` in PL 1.7, so I've added it to the data configuration.

Note: post this PR, it's expected that the users will use latest PL release (>= 1.7.0) 🎉 

cc: @SeanNaren (also cc-ing: @Borda @carmocca for visibility) :) 