### PR TITLE
Replace deprecated function

### DIFF
--- a/deepspeech_pytorch/loader/sparse_image_warp.py
+++ b/deepspeech_pytorch/loader/sparse_image_warp.py
@@ -177,7 +177,7 @@ def solve_interpolation(train_points, train_values, order, regularization_weight
     rhs = torch.cat((f, rhs_zeros), 1)  # [b, n + d + 1, k]
 
     # Then, solve the linear system and unpack the results.
-    X, LU = torch.solve(rhs, lhs)
+    X = torch.linalg.solve(lhs, rhs)
     w = X[:, :n, :]
     v = X[:, n:, :]
 


### PR DESCRIPTION
Hi,

`deepspeech_pytorch/loader/sparse_image_warp.py` was using `torch.solve()`, which has been deprecated since PyTorch v1.9. I changed it to `torch.linalg.solve()`. 